### PR TITLE
Provide page metadata for the index pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: CC-BY-SA-4.0
 
-title: PSA Certified API Specifications
+title: PSA Certified API
 description: The official place for the latest published documents of the PSA Certified API
 logo: assets/img/Arm_logo_blue_RGB.svg
 

--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 # SPDX-License-Identifier: CC-BY-SA-4.0
 
-title: PSA Certified API
-description: The official place for the latest published documents of the PSA Certified API
+title: PSA Certified APIs
+description: The official place for the latest published documents of the PSA Certified APIs
 logo: assets/img/Arm_logo_blue_RGB.svg
 
 remote_theme: pages-themes/minimal@v0.2.0

--- a/attestation/index.md
+++ b/attestation/index.md
@@ -12,11 +12,11 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 The Attestation API provides a way to obtain a health-check token from a device, attesting to its components and serial numbers.
 
-See the [PSA Certified API][psa-api] page for other PSA Certified API specifications.
+See the [PSA Certified APIs][psa-api] page for other PSA Certified APIs.
 
-Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified API GitHub project][psa-api-gh].
+Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified APIs GitHub project][psa-api-gh].
 
-Test suites to verify a correct implementation can be found in the [PSA Certified API Test suites][psa-api-ats].
+Test suites to verify a correct implementation can be found in the [PSA Certified APIs Test suites][psa-api-ats].
 
 [psa-api]:          ../
 [psa-api-gh]:       https://github.com/arm-software/psa-api

--- a/attestation/index.md
+++ b/attestation/index.md
@@ -1,3 +1,8 @@
+---
+title: PSA Certified Attestation API
+description: The Attestation API provides a way to obtain a health-check token from a device, attesting to its components and serial numbers
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/crypto/index.md
+++ b/crypto/index.md
@@ -1,3 +1,8 @@
+---
+title: PSA Certified Crypto API
+description: The Crypto API provides symmetric and asymmetric cryptography, hash, RNG, and key storage services with support for different key lifetime policies
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/crypto/index.md
+++ b/crypto/index.md
@@ -12,11 +12,11 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 The Crypto API provides symmetric and asymmetric cryptography, hash, RNG, and key storage services with support for different key lifetime policies.
 
-See the [PSA Certified API][psa-api] page for other PSA Certified API specifications.
+See the [PSA Certified APIs][psa-api] page for other PSA Certified APIs.
 
-Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified API GitHub project][psa-api-gh].
+Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified APIs GitHub project][psa-api-gh].
 
-Test suites to verify a correct implementation can be found in the [PSA Certified API Test suites][psa-api-ats].
+Test suites to verify a correct implementation can be found in the [PSA Certified APIs Test suites][psa-api-ats].
 
 [psa-api]:          ../
 [psa-api-gh]:       https://github.com/arm-software/psa-api

--- a/fwu/index.md
+++ b/fwu/index.md
@@ -1,3 +1,8 @@
+---
+title: PSA Certified Firmware Update API
+description: The Firmware Update API defines a standard firmware interface for installing firmware updates
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/fwu/index.md
+++ b/fwu/index.md
@@ -12,11 +12,11 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 The Firmware Update API defines a standard firmware interface for installing firmware updates.
 
-See the [PSA Certified API][psa-api] page for other PSA Certified API specifications.
+See the [PSA Certified APIs][psa-api] page for other PSA Certified APIs.
 
-Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified API GitHub project][psa-api-gh].
+Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified APIs GitHub project][psa-api-gh].
 
-Test suites to verify a correct implementation can be found in the [PSA Certified API Test suites][psa-api-ats].
+Test suites to verify a correct implementation can be found in the [PSA Certified APIs Test suites][psa-api-ats].
 
 [psa-api]:          ../
 [psa-api-gh]:       https://github.com/arm-software/psa-api

--- a/index.md
+++ b/index.md
@@ -3,13 +3,13 @@ SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-s
 SPDX-License-Identifier: CC-BY-SA-4.0
 -->
 
-# PSA Certified API Specifications
+# PSA Certified APIs
 
-This is the official place for the latest published documents of the PSA Certified API.
+This is the official place for the latest published documents of the PSA Certified APIs.
 
-Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified API GitHub project][psa-api-gh].
+Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified APIs GitHub project][psa-api-gh].
 
-Test suites to verify a correct implementation can be found in the [PSA Certified API Test suites][psa-api-ats].
+Test suites to verify a correct implementation can be found in the [PSA Certified APIs Test suites][psa-api-ats].
 
 [psa-api-gh]:       https://github.com/arm-software/psa-api
 [psa-api-ats]:      https://github.com/ARM-software/psa-arch-tests/tree/main/api-tests/dev_apis
@@ -17,7 +17,7 @@ Test suites to verify a correct implementation can be found in the [PSA Certifie
 
 ## Specifications
 
-The following specifications are part of the PSA Certified API:
+The following specifications are part of the PSA Certified APIs:
 
 Specification | | | | |
 -|-|-|-|-
@@ -50,7 +50,7 @@ Crypto API | PAKE | 1.1 Beta | [HTML][pake-html] | [&darr; PDF][pake-pdf] | [All
 
 ## Feedback
 
-If you have questions or comments on any of the PSA Certified API specifications, or suggestions for enhancements, please [raise a new issue][psa-api-issue] in the PSA Certified API GitHub project.
+If you have questions or comments on any of the specifications, or suggestions for enhancements, please [raise a new issue][psa-api-issue] in the PSA Certified APIs GitHub project.
 
 Please indicate which specification the issue applies to. This can be done by:
 
@@ -61,7 +61,7 @@ Please indicate which specification the issue applies to. This can be done by:
 
 ## License
 
-The latest PSA Certified API specifications that are hosted on this website are licensed under the Creative Commons [Attribution–Share Alike 4.0 International license][CC-BY-SA-4.0] and [Apache License, Version 2.0][APACHE-2.0]. Some earlier versions of the specifications are licensed under a non-confidential license from Arm.
+The latest versions of the PSA Certified APIs that are hosted on this website are licensed under the Creative Commons [Attribution–Share Alike 4.0 International license][CC-BY-SA-4.0] and [Apache License, Version 2.0][APACHE-2.0]. Some earlier versions of the specifications are licensed under a non-confidential license from Arm.
 
 Refer to individual documents for license details.
 

--- a/status-code/index.md
+++ b/status-code/index.md
@@ -10,13 +10,13 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 # PSA Certified<br />Status code API
 
-The Status code API provides common status and error codes for the PSA Certified API.
+The Status code API provides common status and error codes for the PSA Certified APIs.
 
-See the [PSA Certified API][psa-api] page for other PSA Certified API specifications.
+See the [PSA Certified APIs][psa-api] page for other PSA Certified APIs.
 
-Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified API GitHub project][psa-api-gh].
+Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified APIs GitHub project][psa-api-gh].
 
-Test suites to verify a correct implementation can be found in the [PSA Certified API Test suites][psa-api-ats].
+Test suites to verify a correct implementation can be found in the [PSA Certified APIs Test suites][psa-api-ats].
 
 [psa-api]:          ../
 [psa-api-gh]:       https://github.com/arm-software/psa-api

--- a/status-code/index.md
+++ b/status-code/index.md
@@ -1,3 +1,8 @@
+---
+title: PSA Certified Status code API
+description: The Status code API provides common status and error codes for the PSA Certified API
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/storage/index.md
+++ b/storage/index.md
@@ -1,3 +1,8 @@
+---
+title: PSA Certified Secure Storage API
+description: The Secure Storage API supports data protection services on the device, providing integrity and confidentiality protection
+---
+
 <!--
 SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 SPDX-License-Identifier: CC-BY-SA-4.0

--- a/storage/index.md
+++ b/storage/index.md
@@ -12,11 +12,11 @@ SPDX-License-Identifier: CC-BY-SA-4.0
 
 The Secure Storage API supports data protection services on the device, providing integrity and confidentiality protection.
 
-See the [PSA Certified API][psa-api] page for other PSA Certified API specifications.
+See the [PSA Certified APIs][psa-api] page for other PSA Certified APIs.
 
-Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified API GitHub project][psa-api-gh].
+Specification source files, updates, and discussions, as well as reference headers and example code, can be found in the associated [PSA Certified APIs GitHub project][psa-api-gh].
 
-Test suites to verify a correct implementation can be found in the [PSA Certified API Test suites][psa-api-ats].
+Test suites to verify a correct implementation can be found in the [PSA Certified APIs Test suites][psa-api-ats].
 
 [psa-api]:          ../
 [psa-api-gh]:       https://github.com/arm-software/psa-api


### PR DESCRIPTION
* Add page-specific metadata for each of the index pages on the website, to improve search-engine indexing.
* Align the project title with the PSA Certified website: "PSA Certified APIs"