### PR TITLE
Fix order of elements in Crypto API header

### DIFF
--- a/doc/crypto/api/keys/attributes.rst
+++ b/doc/crypto/api/keys/attributes.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
-    :seq: 11
+    :seq: 12
 
 .. _key-attributes:
 

--- a/doc/crypto/api/keys/ids.rst
+++ b/doc/crypto/api/keys/ids.rst
@@ -1,9 +1,6 @@
 .. SPDX-FileCopyrightText: Copyright 2018-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
-.. header:: psa/crypto
-    :seq: 14
-
 .. _key-identifiers:
 
 Key identifiers
@@ -30,12 +27,18 @@ Valid key identifiers must have distinct values within the same application. If 
 Key identifier type
 -------------------
 
+.. header:: psa/crypto
+    :seq: 11
+
 .. typedef:: uint32_t psa_key_id_t
 
     .. summary::
         Key identifier.
 
     A key identifier can be a permanent name for a persistent key, or a transient reference to volatile key. See :secref:`key-identifiers`.
+
+.. header:: psa/crypto
+    :seq: 15
 
 .. macro:: PSA_KEY_ID_NULL
     :definition: ((psa_key_id_t)0)

--- a/doc/crypto/api/keys/lifetimes.rst
+++ b/doc/crypto/api/keys/lifetimes.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
-    :seq: 13
+    :seq: 14
 
 .. _key-lifetimes:
 

--- a/doc/crypto/api/keys/management.rst
+++ b/doc/crypto/api/keys/management.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
-    :seq: 16
+    :seq: 18
 
 Key management functions
 ========================

--- a/doc/crypto/api/keys/policy.rst
+++ b/doc/crypto/api/keys/policy.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
-    :seq: 15
+    :seq: 17
 
 .. _key-policy:
 

--- a/doc/crypto/api/keys/types.rst
+++ b/doc/crypto/api/keys/types.rst
@@ -2,7 +2,7 @@
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
-    :seq: 12
+    :seq: 13
 
 .. _key-types:
 

--- a/doc/crypto/api/library/library.rst
+++ b/doc/crypto/api/library/library.rst
@@ -11,9 +11,10 @@
     :c++:
     :guard:
     :system-include: stddef.h stdint.h
+    :include: psa/error.h
 
     /* This file is a reference template for implementation of the
-     * PSA Certified Crypto API v1.1.1
+     * PSA Certified Crypto API v1.1
      */
 
 

--- a/doc/crypto/api/ops/algorithms.rst
+++ b/doc/crypto/api/ops/algorithms.rst
@@ -1,9 +1,6 @@
 .. SPDX-FileCopyrightText: Copyright 2018-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
-.. header:: psa/crypto
-    :seq: 20
-
 .. _algorithms:
 
 Algorithms
@@ -31,6 +28,9 @@ The specific algorithm identifiers are described alongside the cryptographic ope
 Algorithm encoding
 ------------------
 
+.. header:: psa/crypto
+    :seq: 16
+
 .. typedef:: uint32_t psa_algorithm_t
 
     .. summary::
@@ -52,6 +52,9 @@ Algorithm encoding
     For algorithms that can be applied to multiple key types, this identifier does not encode the key type. For example, for symmetric ciphers based on a block cipher, `psa_algorithm_t` encodes the block cipher mode and the padding mode while the block cipher itself is encoded via `psa_key_type_t`.
 
     The :secref:`appendix-encodings` appendix provides a full definition of the algorithm identifier encoding.
+
+.. header:: psa/crypto
+    :seq: 20
 
 .. macro:: PSA_ALG_NONE
     :definition: ((psa_algorithm_t)0)

--- a/doc/crypto/conf.py
+++ b/doc/crypto/conf.py
@@ -27,12 +27,12 @@ doc_info = {
     'quality': 'REL',
     # Arm document issue number (within that version and quality status)
     # Marked as open issue if not provided
-    'issue_no': 1,
+    'issue_no': 2,
     # Identifies the sequence number of a release candidate of the same issue
     # default to None
     'release_candidate': None,
     # Draft status - use this to indicate the document is not ready for publication
-    #'draft': True,
+    'draft': True,
 
     # Arm document confidentiality. Must be either Non-confidential or Confidential
     # Marked as open issue if not provided

--- a/headers/crypto/1.1/psa/crypto.h
+++ b/headers/crypto/1.1/psa/crypto.h
@@ -11,6 +11,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "psa/error.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -41,6 +43,11 @@ psa_status_t psa_crypto_init(void);
  * @brief A status code that indicates that the decrypted padding is incorrect.
  */
 #define PSA_ERROR_INVALID_PADDING ((psa_status_t)-150)
+
+/**
+ * @brief Key identifier.
+ */
+typedef uint32_t psa_key_id_t;
 
 /**
  * @brief The type of an object containing key attributes.
@@ -529,11 +536,6 @@ psa_key_lifetime_t psa_get_key_lifetime(const psa_key_attributes_t * attributes)
     ((location) << 8 | (persistence))
 
 /**
- * @brief Key identifier.
- */
-typedef uint32_t psa_key_id_t;
-
-/**
  * @brief The null key identifier.
  */
 #define PSA_KEY_ID_NULL ((psa_key_id_t)0)
@@ -575,6 +577,11 @@ void psa_set_key_id(psa_key_attributes_t * attributes,
  * @return The persistent identifier stored in the attribute object.
  */
 psa_key_id_t psa_get_key_id(const psa_key_attributes_t * attributes);
+
+/**
+ * @brief Encoding of a cryptographic algorithm.
+ */
+typedef uint32_t psa_algorithm_t;
 
 /**
  * @brief Declare the permitted algorithm policy for a key.
@@ -783,11 +790,6 @@ psa_status_t psa_export_public_key(psa_key_id_t key,
  * @brief Sufficient buffer size for exporting any asymmetric public key.
  */
 #define PSA_EXPORT_PUBLIC_KEY_MAX_SIZE /* implementation-defined value */
-
-/**
- * @brief Encoding of a cryptographic algorithm.
- */
-typedef uint32_t psa_algorithm_t;
 
 /**
  * @brief An invalid algorithm identifier value.


### PR DESCRIPTION
The order of the items in the reference header for the Crypto API was not "compiler-ready". Some of the type definitions are used in function declarations before they are defined.

The reference header is also missing the inclusion of psa/error.h.