### PR TITLE
Clarify errors in the storage API

### DIFF
--- a/doc/storage/api/api.rst
+++ b/doc/storage/api/api.rst
@@ -558,14 +558,14 @@ These definitions must be defined in the header file :file:`psa/protected_storag
 
     .. retval:: PSA_SUCCESS
         The storage was successfully reserved.
-    .. retval:: PSA_ERROR_STORAGE_FAILURE
-        The operation failed because the physical storage has failed (Fatal error).
     .. retval:: PSA_ERROR_INSUFFICIENT_STORAGE
         ``capacity`` is bigger than the current available space.
     .. retval:: PSA_ERROR_NOT_SUPPORTED
         The function is not implemented or one or more ``create_flags`` are not supported.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The operation failed because the ``uid`` is ``0``.
+    .. retval:: PSA_ERROR_STORAGE_FAILURE
+        The operation failed because the physical storage has failed (Fatal error).
     .. retval:: PSA_ERROR_GENERIC_ERROR
         The operation has failed due to an unspecified error.
     .. retval:: PSA_ERROR_ALREADY_EXISTS
@@ -609,8 +609,6 @@ These definitions must be defined in the header file :file:`psa/protected_storag
 
     .. retval:: PSA_SUCCESS
         The asset exists, the input parameters are correct and the data is correctly written in the physical storage.
-    .. retval:: PSA_ERROR_STORAGE_FAILURE
-        The data was not written correctly in the physical storage.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The operation failed because either:
 
@@ -623,6 +621,8 @@ These definitions must be defined in the header file :file:`psa/protected_storag
         The specified ``uid`` was not found.
     .. retval:: PSA_ERROR_NOT_SUPPORTED
         The implementation does not support this function.
+    .. retval:: PSA_ERROR_STORAGE_FAILURE
+        The operation failed because the physical storage has failed (Fatal error).
     .. retval:: PSA_ERROR_GENERIC_ERROR
         The operation failed due to an unspecified error.
     .. retval:: PSA_ERROR_DATA_CORRUPT
@@ -648,13 +648,13 @@ These definitions must be defined in the header file :file:`psa/protected_storag
 
     * ``data_offset <= size``
 
-
     * ``data_offset + data_length <= capacity``
+
+    * Even if all parameters are correct, the function can fail in the case of a storage failure.
 
     On Success:
 
     * ``size = max(size, data_offset + data_length)``
-
 
     * ``capacity`` unchanged.
 

--- a/doc/storage/appendix/history.rst
+++ b/doc/storage/appendix/history.rst
@@ -31,3 +31,7 @@ Document history
       - *1.0.1 Rel*
       - * Relicensed the document under Attribution-ShareAlike 4.0 International with a patent license derived from Apache License 2.0. See :secref:`license`.
         * Documentation clarifications.
+
+    * - :issue:`TBD`
+      - *1.?.? Rel*
+      - * Documentation clarifications.

--- a/doc/storage/conf.py
+++ b/doc/storage/conf.py
@@ -27,12 +27,12 @@ doc_info = {
     'quality': 'REL',
     # Arm document issue number (within that version and quality status)
     # Marked as open issue if not provided
-    'issue_no': 1,
+    'issue_no': 2,
     # Identifies the sequence number of a release candidate of the same issue
     # default to None
     'release_candidate': None,
     # Draft status - use this to indicate the document is not ready for publication
-    #'draft': True,
+    'draft': True,
 
     # Arm document confidentiality. Must be either Non-confidential or Confidential
     # Marked as open issue if not provided
@@ -57,6 +57,24 @@ doc_info = {
 
     # Declare a watermark for the PDF output
     #'watermark': 'DRAFT',
+
+    # Optional ordering of return error values
+    # This list is used to create a standard ordering of return value responses
+    # throughout the document, irrespective of their ordering in the source text
+    # Return values that are not in the ordering are sorted above any that are in
+    # the list and appear in source text order.
+
+    'error_order': [
+        'PSA_SUCCESS',
+        'PSA_ERROR_NOT_PERMITTED',
+        'PSA_ERROR_INVALID_SIGNATURE',
+        'PSA_ERROR_DOES_NOT_EXIST',
+        'PSA_ERROR_INVALID_ARGUMENT',
+        'PSA_ERROR_NOT_SUPPORTED',
+        'PSA_ERROR_INSUFFICIENT_STORAGE',
+        'PSA_ERROR_STORAGE_FAILURE',
+        'PSA_ERROR_DATA_CORRUPT',
+    ],
 
     # Include the C Identifier index. Default to True
     'identifier_index': True,


### PR DESCRIPTION
* Use a consistent ordering of the error codes
* Fix description for PSA_ERROR_STORAGE_FAILURE in psa_ps_set_extended(), to match the other APIs