### PR TITLE
Clarify key usage policy documentation

### DIFF
--- a/doc/crypto/api/keys/attributes.rst
+++ b/doc/crypto/api/keys/attributes.rst
@@ -99,9 +99,9 @@ Managing key attributes
         *   -   key size
             -   ``0`` --- meaning that the size is unspecified.
         *   -   usage flags
-            -   ``0`` --- which allows no usage except exporting a public key.
+            -   ``0`` --- which permits no usage except exporting a public key.
         *   -   algorithm
-            -   `PSA_ALG_NONE` --- which does not allow cryptographic usage, but allows exporting.
+            -   `PSA_ALG_NONE` --- which does not permit cryptographic usage, but permits exporting.
 
     .. rubric:: Usage
 

--- a/doc/crypto/api/keys/management.rst
+++ b/doc/crypto/api/keys/management.rst
@@ -202,7 +202,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
         The following conditions can result in this error:
 
         *   ``source_key`` does not have the `PSA_KEY_USAGE_COPY` usage flag.
-        *   ``source_key`` does not have the `PSA_KEY_USAGE_EXPORT` usage flag, and the location of ``target_key`` is outside the security perimeter of the ``source_key`` storage location.
+        *   ``source_key`` does not have the `PSA_KEY_USAGE_EXPORT` usage flag, and the location of ``target_key`` is outside the security boundary of the ``source_key`` storage location.
         *   The implementation does not permit creating a key with the specified attributes due to some implementation-specific policy.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_INSUFFICIENT_STORAGE

--- a/doc/crypto/api/keys/management.rst
+++ b/doc/crypto/api/keys/management.rst
@@ -164,8 +164,8 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
 
     .. param:: psa_key_id_t source_key
         The key to copy.
-        It must allow the usage `PSA_KEY_USAGE_COPY`.
-        If a private or secret key is being copied outside of a secure element it must also allow `PSA_KEY_USAGE_EXPORT`.
+        It must permit the usage `PSA_KEY_USAGE_COPY`.
+        If a private or secret key is being copied outside of a secure element it must also permit `PSA_KEY_USAGE_EXPORT`.
     .. param:: const psa_key_attributes_t * attributes
         The attributes for the new key. This function uses the attributes as follows:
 
@@ -202,7 +202,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
         The following conditions can result in this error:
 
         *   ``source_key`` does not have the `PSA_KEY_USAGE_COPY` usage flag.
-        *   ``source_key`` does not have the `PSA_KEY_USAGE_EXPORT` usage flag, and its storage location does not allow copying it to the target key's storage location.
+        *   ``source_key`` does not have the `PSA_KEY_USAGE_EXPORT` usage flag, and the location of ``target_key`` is outside the security perimeter of the ``source_key`` storage location.
         *   The implementation does not permit creating a key with the specified attributes due to some implementation-specific policy.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_INSUFFICIENT_STORAGE
@@ -226,7 +226,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
 
     *   The usage flags on the resulting key are the bitwise-and of the usage flags on the source policy and the usage flags in ``attributes``.
     *   If both permit the same algorithm or wildcard-based algorithm, the resulting key has the same permitted algorithm.
-    *   If either of the policies permits an algorithm and the other policy allows a wildcard-based permitted algorithm that includes this algorithm, the resulting key uses this permitted algorithm.
+    *   If either of the policies permits an algorithm and the other policy permits a wildcard-based permitted algorithm that includes this algorithm, the resulting key uses this permitted algorithm.
     *   If the policies do not permit any algorithm in common, this function fails with the status :code:`PSA_ERROR_INVALID_ARGUMENT`.
 
     The effect of this function on implementation-defined attributes is implementation-defined.
@@ -321,7 +321,7 @@ Key export
 
     .. param:: psa_key_id_t key
         Identifier of the key to export.
-        It must allow the usage `PSA_KEY_USAGE_EXPORT`, unless it is a public key.
+        It must permit the usage `PSA_KEY_USAGE_EXPORT`, unless it is a public key.
     .. param:: uint8_t * data
         Buffer where the key data is to be written.
     .. param:: size_t data_size

--- a/doc/crypto/api/keys/policy.rst
+++ b/doc/crypto/api/keys/policy.rst
@@ -34,8 +34,8 @@ The following algorithm policies are supported:
 *   A specific algorithm value permits exactly that particular algorithm.
 *   A signature algorithm constructed with `PSA_ALG_ANY_HASH` permits the specified signature scheme with any hash algorithm. In addition, :code:`PSA_ALG_RSA_PKCS1V15_SIGN(PSA_ALG_ANY_HASH)` also permits the `PSA_ALG_RSA_PKCS1V15_SIGN_RAW` signature algorithm.
 *   A raw key agreement algorithm also permits the specified key agreement scheme to be combined with any key derivation algorithm.
-*   An algorithm built from `PSA_ALG_AT_LEAST_THIS_LENGTH_MAC()` allows any MAC algorithm from the same base class (for example, CMAC) which computes or verifies a MAC length greater than or equal to the length encoded in the wildcard algorithm.
-*   An algorithm built from `PSA_ALG_AEAD_WITH_AT_LEAST_THIS_LENGTH_TAG()` allows any AEAD algorithm from the same base class (for example, CCM) which computes or verifies a tag length greater than or equal to the length encoded in the wildcard algorithm.
+*   An algorithm built from `PSA_ALG_AT_LEAST_THIS_LENGTH_MAC()` permits any MAC algorithm from the same base class (for example, CMAC) which computes or verifies a MAC length greater than or equal to the length encoded in the wildcard algorithm.
+*   An algorithm built from `PSA_ALG_AEAD_WITH_AT_LEAST_THIS_LENGTH_TAG()` permits any AEAD algorithm from the same base class (for example, CCM) which computes or verifies a tag length greater than or equal to the length encoded in the wildcard algorithm.
 
 When a key is used in a cryptographic operation, the application must supply the algorithm to use for the operation. This algorithm is checked against the key's permitted-algorithm policy.
 
@@ -82,7 +82,7 @@ Key usage flags
 
 The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. Four kinds of usage flag can be specified:
 
-*   The extractable flag `PSA_KEY_USAGE_EXPORT` determines whether the key material can be extracted.
+*   The extractable flag `PSA_KEY_USAGE_EXPORT` determines whether the key material can be extracted from the cryptoprocessor, or copied outside of its current security domain.
 *   The copyable flag `PSA_KEY_USAGE_COPY` determines whether the key material can be copied into a new key, which can have a different lifetime or a more restrictive policy.
 *   The cacheable flag `PSA_KEY_USAGE_CACHE` determines whether the implementation is permitted to retain non-essential copies of the key material in RAM. This policy only applies to persistent keys. See also :secref:`key-material`.
 *   The other usage flags, for example, `PSA_KEY_USAGE_ENCRYPT` and `PSA_KEY_USAGE_SIGN_MESSAGE`, determine whether the corresponding operation is permitted on the key.
@@ -98,11 +98,13 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission to export the key.
 
-    This flag allows the use of `psa_export_key()` to export a key from the cryptoprocessor. A public key or the public part of a key pair can always be exported regardless of the value of this permission flag.
+    This flag permits a key to be moved outside of the security boundary of its current storage location. In particular:
 
-    This flag can also be required to copy a key using `psa_copy_key()` outside of a secure element. See also `PSA_KEY_USAGE_COPY`.
+    *   This flag is required to export a key from the cryptoprocessor using `psa_export_key()`. A public key or the public part of a key pair can always be exported regardless of the value of this permission flag.
 
-    If a key does not have export permission, implementations must not allow the key to be exported in plain form from the cryptoprocessor, whether through `psa_export_key()` or through a proprietary interface. The key might still be exportable in a wrapped form, i.e. in a form where it is encrypted by another key.
+    *   This flag can also be required to make a copy of a key outside of a secure element using `psa_copy_key()`. See also `PSA_KEY_USAGE_COPY`.
+
+    If a key does not have export permission, implementations must not permit the key to be exported in plain form from the cryptoprocessor, whether through `psa_export_key()` or through a proprietary interface. The key might still be exportable in a wrapped form, i.e. in a form where it is encrypted by another key.
 
 .. macro:: PSA_KEY_USAGE_COPY
     :definition: ((psa_key_usage_t)0x00000002)
@@ -110,9 +112,9 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission to copy the key.
 
-    This flag allows the use of `psa_copy_key()` to make a copy of the key with the same policy or a more restrictive policy.
+    This flag is required to make a copy of a key using `psa_copy_key()`.
 
-    For lifetimes for which the key is located in a secure element which enforce the non-exportability of keys, copying a key outside the secure element also requires the usage flag `PSA_KEY_USAGE_EXPORT`. Copying the key inside the secure element is permitted with just `PSA_KEY_USAGE_COPY` if the secure element supports it. For keys with the lifetime `PSA_KEY_LIFETIME_VOLATILE` or `PSA_KEY_LIFETIME_PERSISTENT`, the usage flag `PSA_KEY_USAGE_COPY` is sufficient to permit the copy.
+    For a key lifetime that corresponds to a secure element location that enforces the non-exportability of keys, copying a key outside the secure element also requires the usage flag `PSA_KEY_USAGE_EXPORT`. Copying the key within the secure element is permitted with just `PSA_KEY_USAGE_COPY`, if the secure element supports it. For keys with the lifetime `PSA_KEY_LIFETIME_VOLATILE` or `PSA_KEY_LIFETIME_PERSISTENT`, the usage flag `PSA_KEY_USAGE_COPY` is sufficient to permit the copy.
 
 .. macro:: PSA_KEY_USAGE_CACHE
     :definition: ((psa_key_usage_t)0x00000004)
@@ -120,7 +122,7 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission for the implementation to cache the key.
 
-    This flag allows the implementation to make additional copies of the key material that are not in storage and not for the purpose of an ongoing operation. Applications can use it as a hint to keep the key around for repeated access.
+    This flag permits the implementation to make additional copies of the key material that are not in storage and not for the purpose of an ongoing operation. Applications can use it as a hint for the cryptoprocessor, to keep a copy of the key around for repeated access.
 
     An application can request that cached key material is removed from memory by calling `psa_purge_key()`.
 
@@ -129,7 +131,7 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     *   An implementation is not required to cache keys that have this usage flag.
     *   An implementation must not report an error if it does not cache keys.
 
-    If this usage flag is not present, the implementation must ensure key material is removed from memory as soon as it is not required for an operation or for maintenance of a volatile key.
+    If this usage flag is not present, the implementation must ensure key material is removed from memory as soon as it is not required for an operation, or for maintenance of a volatile key.
 
     This flag must be preserved when reading back the attributes for all keys, regardless of key type or implementation behavior.
 
@@ -141,7 +143,7 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission to encrypt a message with the key.
 
-    This flag allows the key to be used for a symmetric encryption operation, for an AEAD encryption-and-authentication operation, or for an asymmetric encryption operation, if otherwise permitted by the key's type and policy. The flag must be present on keys used with the following APIs:
+    This flag is required to use the key in a symmetric encryption operation, in an AEAD encryption-and-authentication operation, or in an asymmetric encryption operation. The flag must be present on keys used with the following APIs:
 
     *   `psa_cipher_encrypt()`
     *   `psa_cipher_encrypt_setup()`
@@ -157,7 +159,7 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission to decrypt a message with the key.
 
-    This flag allows the key to be used for a symmetric decryption operation, for an AEAD decryption-and-verification operation, or for an asymmetric decryption operation, if otherwise permitted by the key's type and policy. The flag must be present on keys used with the following APIs:
+    This flag is required to use the key in a symmetric decryption operation, in an AEAD decryption-and-verification operation, or in an asymmetric decryption operation. The flag must be present on keys used with the following APIs:
 
     *   `psa_cipher_decrypt()`
     *   `psa_cipher_decrypt_setup()`
@@ -173,7 +175,7 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission to sign a message with the key.
 
-    This flag allows the key to be used for a MAC calculation operation or for an asymmetric message signature operation, if otherwise permitted by the key's type and policy. The flag must be present on keys used with the following APIs:
+    This flag is required to use the key in a MAC calculation operation, or in an asymmetric message signature operation. The flag must be present on keys used with the following APIs:
 
     *   `psa_mac_compute()`
     *   `psa_mac_sign_setup()`
@@ -187,7 +189,7 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission to verify a message signature with the key.
 
-    This flag allows the key to be used for a MAC verification operation or for an asymmetric message signature verification operation, if otherwise permitted by the key's type and policy. The flag must be present on keys used with the following APIs:
+    This flag is required to use the key in a MAC verification operation, or in an asymmetric message signature verification operation. The flag must be present on keys used with the following APIs:
 
     *   `psa_mac_verify()`
     *   `psa_mac_verify_setup()`
@@ -201,7 +203,7 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission to sign a message hash with the key.
 
-    This flag allows the key to be used to sign a message hash as part of an asymmetric signature operation, if otherwise permitted by the key's type and policy. The flag must be present on keys used when calling `psa_sign_hash()`.
+    This flag is required to use the key to sign a message hash in an asymmetric signature operation. The flag must be present on keys used when calling `psa_sign_hash()`.
 
     This flag automatically sets `PSA_KEY_USAGE_SIGN_MESSAGE`: if an application sets the flag `PSA_KEY_USAGE_SIGN_HASH` when creating a key, then the key always has the permissions conveyed by `PSA_KEY_USAGE_SIGN_MESSAGE`, and the flag `PSA_KEY_USAGE_SIGN_MESSAGE` will also be present when the application queries the usage flags of the key.
 
@@ -213,7 +215,7 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission to verify a message hash with the key.
 
-    This flag allows the key to be used to verify a message hash as part of an asymmetric signature verification operation, if otherwise permitted by the key's type and policy. The flag must be present on keys used when calling `psa_verify_hash()`.
+    This flag is required to use the key to verify a message hash in an asymmetric signature verification operation. The flag must be present on keys used when calling `psa_verify_hash()`.
 
     This flag automatically sets `PSA_KEY_USAGE_VERIFY_MESSAGE`: if an application sets the flag `PSA_KEY_USAGE_VERIFY_HASH` when creating a key, then the key always has the permissions conveyed by `PSA_KEY_USAGE_VERIFY_MESSAGE`, and the flag `PSA_KEY_USAGE_VERIFY_MESSAGE` will also be present when the application queries the usage flags of the key.
 
@@ -225,7 +227,7 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission to derive other keys or produce a password hash from this key.
 
-    This flag allows the key to be used for a key derivation operation or for a key agreement operation, if otherwise permitted by the key's type and policy.
+    This flag is required to use the key for derivation in a key derivation operation, or in a key agreement operation.
 
     This flag must be present on keys used with the following APIs:
 
@@ -240,7 +242,7 @@ The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. 
     .. summary::
         Permission to verify the result of a key derivation, including password hashing.
 
-    This flag allows the key to be used in a key derivation operation, if otherwise permitted by the key's type and policy.
+    This flag is required to use the key for verification in a key derivation operation.
 
     This flag must be present on keys used with `psa_key_derivation_verify_key()`.
 

--- a/doc/crypto/api/keys/policy.rst
+++ b/doc/crypto/api/keys/policy.rst
@@ -82,7 +82,7 @@ Key usage flags
 
 The usage flags are encoded in a bitmask, which has the type `psa_key_usage_t`. Four kinds of usage flag can be specified:
 
-*   The extractable flag `PSA_KEY_USAGE_EXPORT` determines whether the key material can be extracted from the cryptoprocessor, or copied outside of its current security domain.
+*   The extractable flag `PSA_KEY_USAGE_EXPORT` determines whether the key material can be extracted from the cryptoprocessor, or copied outside of its current security boundary.
 *   The copyable flag `PSA_KEY_USAGE_COPY` determines whether the key material can be copied into a new key, which can have a different lifetime or a more restrictive policy.
 *   The cacheable flag `PSA_KEY_USAGE_CACHE` determines whether the implementation is permitted to retain non-essential copies of the key material in RAM. This policy only applies to persistent keys. See also :secref:`key-material`.
 *   The other usage flags, for example, `PSA_KEY_USAGE_ENCRYPT` and `PSA_KEY_USAGE_SIGN_MESSAGE`, determine whether the corresponding operation is permitted on the key.

--- a/doc/crypto/api/ops/aead.rst
+++ b/doc/crypto/api/ops/aead.rst
@@ -172,7 +172,7 @@ AEAD algorithms
     .. param:: aead_alg
         An AEAD algorithm: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_AEAD(aead_alg)` is true.
     .. param:: min_tag_length
-        Desired minimum length of the authentication tag in bytes. This must be at least ``1`` and at most the largest allowed tag length of the algorithm.
+        Desired minimum length of the authentication tag in bytes. This must be at least ``1`` and at most the largest permitted tag length of the algorithm.
 
     .. return::
         The corresponding AEAD wildcard algorithm with the specified minimum tag length.
@@ -182,7 +182,7 @@ AEAD algorithms
     A key with a minimum-tag-length AEAD wildcard algorithm as permitted-algorithm policy can be used with all AEAD algorithms sharing the same base algorithm, and where the tag length of the specific algorithm is equal to or larger then the minimum tag length specified by the wildcard algorithm.
 
     .. note::
-        When setting the minimum required tag length to less than the smallest tag length allowed by the base algorithm, this effectively becomes an 'any-tag-length-allowed' policy for that base algorithm.
+        When setting the minimum required tag length to less than the smallest tag length permitted by the base algorithm, this effectively becomes an 'any-tag-length-permitted' policy for that base algorithm.
 
     The AEAD algorithm with a default length tag can be recovered using `PSA_ALG_AEAD_WITH_DEFAULT_LENGTH_TAG()`.
 
@@ -201,7 +201,7 @@ Single-part AEAD functions
 
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation.
-        It must allow the usage `PSA_KEY_USAGE_ENCRYPT`.
+        It must permit the usage `PSA_KEY_USAGE_ENCRYPT`.
     .. param:: psa_algorithm_t alg
         The AEAD algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_AEAD(alg)` is true.
     .. param:: const uint8_t * nonce
@@ -267,7 +267,7 @@ Single-part AEAD functions
 
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation.
-        It must allow the usage `PSA_KEY_USAGE_DECRYPT`.
+        It must permit the usage `PSA_KEY_USAGE_DECRYPT`.
     .. param:: psa_algorithm_t alg
         The AEAD algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_AEAD(alg)` is true.
     .. param:: const uint8_t * nonce
@@ -406,7 +406,7 @@ Multi-part AEAD operations
         The operation object to set up. It must have been initialized as per the documentation for `psa_aead_operation_t` and not yet in use.
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation. It must remain valid until the operation terminates.
-        It must allow the usage `PSA_KEY_USAGE_ENCRYPT`.
+        It must permit the usage `PSA_KEY_USAGE_ENCRYPT`.
     .. param:: psa_algorithm_t alg
         The AEAD algorithm: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_AEAD(alg)` is true.
 
@@ -470,7 +470,7 @@ Multi-part AEAD operations
         The operation object to set up. It must have been initialized as per the documentation for `psa_aead_operation_t` and not yet in use.
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation. It must remain valid until the operation terminates.
-        It must allow the usage `PSA_KEY_USAGE_DECRYPT`.
+        It must permit the usage `PSA_KEY_USAGE_DECRYPT`.
     .. param:: psa_algorithm_t alg
         The AEAD algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_AEAD(alg)` is true.
 

--- a/doc/crypto/api/ops/ciphers.rst
+++ b/doc/crypto/api/ops/ciphers.rst
@@ -284,7 +284,7 @@ Single-part cipher functions
 
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation.
-        It must allow the usage `PSA_KEY_USAGE_ENCRYPT`.
+        It must permit the usage `PSA_KEY_USAGE_ENCRYPT`.
     .. param:: psa_algorithm_t alg
         The cipher algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_CIPHER(alg)` is true.
     .. param:: const uint8_t * input
@@ -346,7 +346,7 @@ Single-part cipher functions
 
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation. It must remain valid until the operation terminates.
-        It must allow the usage `PSA_KEY_USAGE_DECRYPT`.
+        It must permit the usage `PSA_KEY_USAGE_DECRYPT`.
     .. param:: psa_algorithm_t alg
         The cipher algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_CIPHER(alg)` is true.
     .. param:: const uint8_t * input
@@ -463,7 +463,7 @@ Multi-part cipher operations
         The operation object to set up. It must have been initialized as per the documentation for `psa_cipher_operation_t` and not yet in use.
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation. It must remain valid until the operation terminates.
-        It must allow the usage `PSA_KEY_USAGE_ENCRYPT`.
+        It must permit the usage `PSA_KEY_USAGE_ENCRYPT`.
     .. param:: psa_algorithm_t alg
         The cipher algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_CIPHER(alg)` is true.
 
@@ -525,7 +525,7 @@ Multi-part cipher operations
         The operation object to set up. It must have been initialized as per the documentation for `psa_cipher_operation_t` and not yet in use.
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation. It must remain valid until the operation terminates.
-        It must allow the usage `PSA_KEY_USAGE_DECRYPT`.
+        It must permit the usage `PSA_KEY_USAGE_DECRYPT`.
     .. param:: psa_algorithm_t alg
         The cipher algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_CIPHER(alg)` is true.
 

--- a/doc/crypto/api/ops/ka.rst
+++ b/doc/crypto/api/ops/ka.rst
@@ -123,7 +123,7 @@ Standalone key agreement
         The key agreement algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_RAW_KEY_AGREEMENT(alg)` is true.
     .. param:: psa_key_id_t private_key
         Identifier of the private key to use.
-        It must allow the usage `PSA_KEY_USAGE_DERIVE`.
+        It must permit the usage `PSA_KEY_USAGE_DERIVE`.
     .. param:: const uint8_t * peer_key
         Public key of the peer. The peer key must be in the same format that `psa_import_key()` accepts for the public key type corresponding to the type of ``private_key``. That is, this function performs the equivalent of :code:`psa_import_key(..., peer_key, peer_key_length)`, with key attributes indicating the public key type corresponding to the type of ``private_key``. For example, for ECC keys, this means that peer_key is interpreted as a point on the curve that the private key is on. The standard formats for public keys are documented in the documentation of `psa_export_public_key()`.
     .. param:: size_t peer_key_length
@@ -190,7 +190,7 @@ Combining key agreement and key derivation
         Which step the input data is for.
     .. param:: psa_key_id_t private_key
         Identifier of the private key to use.
-        It must allow the usage `PSA_KEY_USAGE_DERIVE`.
+        It must permit the usage `PSA_KEY_USAGE_DERIVE`.
     .. param:: const uint8_t * peer_key
         Public key of the peer. The peer key must be in the same format that `psa_import_key()` accepts for the public key type corresponding to the type of ``private_key``. That is, this function performs the equivalent of :code:`psa_import_key(..., peer_key, peer_key_length)`, with key attributes indicating the public key type corresponding to the type of ``private_key``. For example, for ECC keys, this means that peer_key is interpreted as a point on the curve that the private key is on. The standard formats for public keys are documented in the documentation of `psa_export_public_key()`.
     .. param:: size_t peer_key_length
@@ -212,7 +212,7 @@ Combining key agreement and key derivation
         The following conditions can result in this error:
 
         *   The operation's algorithm is not a key agreement algorithm.
-        *   ``step`` does not allow an input resulting from a key agreement.
+        *   ``step`` does not permit an input resulting from a key agreement.
         *   ``private_key`` is not compatible with the operation's algorithm.
         *   ``peer_key`` is not a valid public key corresponding to ``private_key``.
     .. retval:: PSA_ERROR_NOT_SUPPORTED

--- a/doc/crypto/api/ops/kdf.rst
+++ b/doc/crypto/api/ops/kdf.rst
@@ -295,7 +295,7 @@ Input step types
 
     This is typically a key of type `PSA_KEY_TYPE_DERIVE` passed to `psa_key_derivation_input_key()`, or the shared secret resulting from a key agreement obtained via `psa_key_derivation_key_agreement()`.
 
-    The secret can also be a direct input passed to `psa_key_derivation_input_bytes()`. In this case, the derivation operation cannot be used to derive keys: the operation will not allow a call to `psa_key_derivation_output_key()`.
+    The secret can also be a direct input passed to `psa_key_derivation_input_bytes()`. In this case, the derivation operation cannot be used to derive keys: the operation will not permit a call to `psa_key_derivation_output_key()`.
 
 .. macro:: PSA_KEY_DERIVATION_INPUT_OTHER_SECRET
     :definition: /* implementation-defined value */
@@ -313,7 +313,7 @@ Input step types
 
     This is usually a key of type `PSA_KEY_TYPE_PASSWORD` passed to `psa_key_derivation_input_key()` or a direct input passed to `psa_key_derivation_input_bytes()` that is a password or passphrase. It can also be high-entropy secret, for example, a key of type `PSA_KEY_TYPE_DERIVE`, or the shared secret resulting from a key agreement.
 
-    If the secret is a direct input, the derivation operation cannot be used to derive keys: the operation will not allow a call to `psa_key_derivation_output_key()`.
+    If the secret is a direct input, the derivation operation cannot be used to derive keys: the operation will not permit a call to `psa_key_derivation_output_key()`.
 
 .. macro:: PSA_KEY_DERIVATION_INPUT_LABEL
     :definition: /* implementation-defined value */
@@ -538,7 +538,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   ``step`` is not compatible with the operation's algorithm.
-        *   ``step`` does not allow direct inputs.
+        *   ``step`` does not permit direct inputs.
         *   ``data_length`` is too small or too large for ``step`` in this particular algorithm.
     .. retval:: PSA_ERROR_NOT_SUPPORTED
         The following conditions can result in this error:
@@ -582,7 +582,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   ``step`` is not compatible with the operation's algorithm.
-        *   ``step`` does not allow numerical inputs.
+        *   ``step`` does not permit numerical inputs.
         *   ``value`` is not valid for ``step`` in the operation's algorithm.
     .. retval:: PSA_ERROR_NOT_SUPPORTED
         The following conditions can result in this error:
@@ -619,7 +619,7 @@ Key derivation functions
     .. param:: psa_key_derivation_step_t step
         Which step the input data is for.
     .. param:: psa_key_id_t key
-        Identifier of the key. The key must have an appropriate type for ``step``, it must allow the usage `PSA_KEY_USAGE_DERIVE` or `PSA_KEY_USAGE_VERIFY_DERIVATION` (see note_), and it must permit the algorithm used by the operation.
+        Identifier of the key. The key must have an appropriate type for ``step``, it must permit the usage `PSA_KEY_USAGE_DERIVE` or `PSA_KEY_USAGE_VERIFY_DERIVATION` (see note_), and it must permit the algorithm used by the operation.
 
     .. return:: psa_status_t
     .. retval:: PSA_SUCCESS
@@ -632,7 +632,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   ``step`` is not compatible with the operation's algorithm.
-        *   ``step`` does not allow key inputs of the given type, or does not allow key inputs at all.
+        *   ``step`` does not permit key inputs of the given type, or does not permit key inputs at all.
     .. retval:: PSA_ERROR_NOT_SUPPORTED
         The following conditions can result in this error:
 
@@ -683,7 +683,7 @@ Key derivation functions
         Success.
         The first ``output_length`` bytes of ``output`` contain the derived data.
     .. retval:: PSA_ERROR_NOT_PERMITTED
-        One of the inputs was a key whose policy did not allow `PSA_KEY_USAGE_DERIVE`.
+        One of the inputs was a key whose policy did not permit `PSA_KEY_USAGE_DERIVE`.
     .. retval:: PSA_ERROR_INSUFFICIENT_DATA
         The operation's capacity was less than ``output_length`` bytes. In this case, the following occurs:
 
@@ -759,7 +759,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The `PSA_KEY_DERIVATION_INPUT_SECRET` input step was neither provided through a key, nor the result of a key agreement.
-        *   One of the inputs was a key whose policy did not allow `PSA_KEY_USAGE_DERIVE`.
+        *   One of the inputs was a key whose policy did not permit `PSA_KEY_USAGE_DERIVE`.
         *   The implementation does not permit creating a key with the specified attributes due to some implementation-specific policy.
     .. retval:: PSA_ERROR_BAD_STATE
         The following conditions can result in this error:
@@ -940,7 +940,7 @@ Key derivation functions
         if (memcmp(expected_output, tmp, output_length) != 0)
             return PSA_ERROR_INVALID_SIGNATURE;
 
-    However, calling `psa_key_derivation_verify_bytes()` works even if the key's policy does not allow output of the bytes.
+    However, calling `psa_key_derivation_verify_bytes()` works even if the key's policy does not permit output of the bytes.
 
     If this function returns an error status other than :code:`PSA_ERROR_INSUFFICIENT_DATA` or :code:`PSA_ERROR_INVALID_SIGNATURE`, the operation enters an error state and must be aborted by calling `psa_key_derivation_abort()`.
 
@@ -956,7 +956,7 @@ Key derivation functions
         The key derivation operation object to read from.
     .. param:: psa_key_id_t expected
         A key of type `PSA_KEY_TYPE_PASSWORD_HASH` containing the expected output.
-        The key must allow the usage `PSA_KEY_USAGE_VERIFY_DERIVATION`, and the permitted algorithm must match the operation's algorithm.
+        The key must permit the usage `PSA_KEY_USAGE_VERIFY_DERIVATION`, and the permitted algorithm must match the operation's algorithm.
 
         The value of this key is typically computed by a previous call to psa_key_derivation_output_key().
 

--- a/doc/crypto/api/ops/macs.rst
+++ b/doc/crypto/api/ops/macs.rst
@@ -159,7 +159,7 @@ MAC algorithms
     A key with a minimum-MAC-length MAC wildcard algorithm as permitted-algorithm policy can be used with all MAC algorithms sharing the same base algorithm, and where the (potentially truncated) MAC length of the specific algorithm is equal to or larger then the wildcard algorithm's minimum MAC length.
 
     ..  note::
-        When setting the minimum required MAC length to less than the smallest MAC length allowed by the base algorithm, this effectively becomes an 'any-MAC-length-allowed' policy for that base algorithm.
+        When setting the minimum required MAC length to less than the smallest MAC length permitted by the base algorithm, this effectively becomes an 'any-MAC-length-permitted' policy for that base algorithm.
 
     The untruncated MAC algorithm can be recovered using `PSA_ALG_FULL_LENGTH_MAC()`.
 
@@ -178,7 +178,7 @@ Single-part MAC functions
 
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation.
-        It must allow the usage `PSA_KEY_USAGE_SIGN_MESSAGE`.
+        It must permit the usage `PSA_KEY_USAGE_SIGN_MESSAGE`.
     .. param:: psa_algorithm_t alg
         The MAC algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_MAC(alg)` is true.
     .. param:: const uint8_t * input
@@ -239,7 +239,7 @@ Single-part MAC functions
 
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation.
-        It must allow the usage `PSA_KEY_USAGE_VERIFY_MESSAGE`.
+        It must permit the usage `PSA_KEY_USAGE_VERIFY_MESSAGE`.
     .. param:: psa_algorithm_t alg
         The MAC algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_MAC(alg)` is true.
     .. param:: const uint8_t * input
@@ -342,7 +342,7 @@ Multi-part MAC operations
         The operation object to set up. It must have been initialized as per the documentation for `psa_mac_operation_t` and not yet in use.
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation. It must remain valid until the operation terminates.
-        It must allow the usage `PSA_KEY_USAGE_SIGN_MESSAGE`.
+        It must permit the usage `PSA_KEY_USAGE_SIGN_MESSAGE`.
     .. param:: psa_algorithm_t alg
         The MAC algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_MAC(alg)` is true.
 
@@ -405,7 +405,7 @@ Multi-part MAC operations
         The operation object to set up. It must have been initialized as per the documentation for `psa_mac_operation_t` and not yet in use.
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation. It must remain valid until the operation terminates.
-        It must allow the usage `PSA_KEY_USAGE_VERIFY_MESSAGE`.
+        It must permit the usage `PSA_KEY_USAGE_VERIFY_MESSAGE`.
     .. param:: psa_algorithm_t alg
         The MAC algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_MAC(alg)` is true.
 

--- a/doc/crypto/api/ops/pke.rst
+++ b/doc/crypto/api/ops/pke.rst
@@ -63,7 +63,7 @@ Asymmetric encryption functions
 
     .. param:: psa_key_id_t key
         Identifer of the key to use for the operation. It must be a public key or an asymmetric key pair.
-        It must allow the usage `PSA_KEY_USAGE_ENCRYPT`.
+        It must permit the usage `PSA_KEY_USAGE_ENCRYPT`.
     .. param:: psa_algorithm_t alg
         The asymmetric encryption algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_ASYMMETRIC_ENCRYPTION(alg)` is true.
     .. param:: const uint8_t * input
@@ -129,7 +129,7 @@ Asymmetric encryption functions
 
     .. param:: psa_key_id_t key
         Identifier of the key to use for the operation. It must be an asymmetric key pair.
-        It must allow the usage `PSA_KEY_USAGE_DECRYPT`.
+        It must permit the usage `PSA_KEY_USAGE_DECRYPT`.
     .. param:: psa_algorithm_t alg
         The asymmetric encryption algorithm to compute: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_ASYMMETRIC_ENCRYPTION(alg)` is true.
     .. param:: const uint8_t * input

--- a/doc/crypto/api/ops/sign.rst
+++ b/doc/crypto/api/ops/sign.rst
@@ -357,7 +357,7 @@ Asymmetric signature functions
         Sign a message with a private key. For hash-and-sign algorithms, this includes the hashing step.
 
     .. param:: psa_key_id_t key
-        Identifier of the key to use for the operation. It must be an asymmetric key pair. The key must allow the usage `PSA_KEY_USAGE_SIGN_MESSAGE`.
+        Identifier of the key to use for the operation. It must be an asymmetric key pair. The key must permit the usage `PSA_KEY_USAGE_SIGN_MESSAGE`.
     .. param:: psa_algorithm_t alg
         An asymmetric signature algorithm: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_SIGN_MESSAGE(alg)` is true.
     .. param:: const uint8_t * input
@@ -418,7 +418,7 @@ Asymmetric signature functions
         Verify the signature of a message with a public key. For hash-and-sign algorithms, this includes the hashing step.
 
     .. param:: psa_key_id_t key
-        Identifier of the key to use for the operation. It must be a public key or an asymmetric key pair. The key must allow the usage `PSA_KEY_USAGE_VERIFY_MESSAGE`.
+        Identifier of the key to use for the operation. It must be a public key or an asymmetric key pair. The key must permit the usage `PSA_KEY_USAGE_VERIFY_MESSAGE`.
     .. param:: psa_algorithm_t alg
         An asymmetric signature algorithm: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_SIGN_MESSAGE(alg)` is true.
     .. param:: const uint8_t * input
@@ -470,7 +470,7 @@ Asymmetric signature functions
         Sign an already-calculated hash with a private key.
 
     .. param:: psa_key_id_t key
-        Identifier of the key to use for the operation. It must be an asymmetric key pair. The key must allow the usage `PSA_KEY_USAGE_SIGN_HASH`.
+        Identifier of the key to use for the operation. It must be an asymmetric key pair. The key must permit the usage `PSA_KEY_USAGE_SIGN_HASH`.
     .. param:: psa_algorithm_t alg
         An asymmetric signature algorithm that separates the hash and sign operations: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_SIGN_HASH(alg)` is true.
     .. param:: const uint8_t * hash
@@ -543,7 +543,7 @@ Asymmetric signature functions
         Verify the signature of a hash or short message using a public key.
 
     .. param:: psa_key_id_t key
-        Identifier of the key to use for the operation. It must be a public key or an asymmetric key pair. The key must allow the usage `PSA_KEY_USAGE_VERIFY_HASH`.
+        Identifier of the key to use for the operation. It must be a public key or an asymmetric key pair. The key must permit the usage `PSA_KEY_USAGE_VERIFY_HASH`.
     .. param:: psa_algorithm_t alg
         An asymmetric signature algorithm that separates the hash and sign operations: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_SIGN_HASH(alg)` is true.
     .. param:: const uint8_t * hash

--- a/doc/crypto/appendix/encodings.rst
+++ b/doc/crypto/appendix/encodings.rst
@@ -130,7 +130,7 @@ The defined values for HASH-TYPE are shown in :numref:`table-hash-type`.
     SHAKE256-512, ``0x15``, `PSA_ALG_SHAKE256_512`, ``0x02000015``
     *wildcard* :sup:`a`, ``0xFF``, `PSA_ALG_ANY_HASH`, ``0x020000FF``
 
-a.  The wildcard hash `PSA_ALG_ANY_HASH` can be used to parameterize a signature algorithm which defines a key usage policy, allowing any hash algorithm to be specified in a signature operation using the key.
+a.  The wildcard hash `PSA_ALG_ANY_HASH` can be used to parameterize a signature algorithm which defines a key usage policy, permitting any hash algorithm to be specified in a signature operation using the key.
 
 .. _mac-encoding:
 

--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -20,10 +20,11 @@ Changes to the API
 Clarifications and fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-*   Clarify the requirements on the ``hash`` parameter in the `psa_sign_hash()` and `psa_verify_hash()` functions.
-*   Explicitly describe the handling of input and output in `psa_cipher_update()`, consistent with the documentation of `psa_aead_update()`.
+*   Clarified the requirements on the ``hash`` parameter in the `psa_sign_hash()` and `psa_verify_hash()` functions.
+*   Explicitly described the handling of input and output in `psa_cipher_update()`, consistent with the documentation of `psa_aead_update()`.
 *   Clarified the behavior of operation objects following a call to a setup function. Provided a diagram to illustrate :ref:`multi-part operation states <multi-part-operations>`.
-*   Clarify the key policy requirement for `PSA_ALG_ECDSA_ANY`.
+*   Clarified the key policy requirement for `PSA_ALG_ECDSA_ANY`.
+*   Clarified `PSA_KEY_USAGE_EXPORT`: "it permits moving a key outside of its current security boundary". This improves understanding of why it is not only required for `psa_export_key()`, but can also be required for `psa_copy_key()` in some situations.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/doc/crypto/overview/implementation.rst
+++ b/doc/crypto/overview/implementation.rst
@@ -105,7 +105,7 @@ does not support a certain algorithm or key type can define such macros in a
 simpler way that does not take unsupported argument values into account.
 
 Some macros define the minimum sufficient output buffer size for certain
-functions. In some cases, an implementation is allowed to require a buffer size
+functions. In some cases, an implementation is permitted to require a buffer size
 that is larger than the theoretical minimum. An implementation must define
 minimum-size macros in such a way that it guarantees that the buffer of the
 resulting size is sufficient for the output of the corresponding function. Refer

--- a/doc/ext-pake/api/pake.rst
+++ b/doc/ext-pake/api/pake.rst
@@ -648,7 +648,7 @@ PAKE step types
     *   For Montgomery curves, the encoding is little endian.
     *   For other Elliptic curves, and for Diffie-Hellman groups, the encoding is big endian. See :cite:`SEC1` §2.3.8.
 
-    In both cases leading zeroes are allowed as long as the length in bytes does not exceed the byte length of the group order.
+    In both cases leading zeroes are permitted as long as the length in bytes does not exceed the byte length of the group order.
 
     For information regarding how the group is determined, consult the documentation `PSA_PAKE_PRIMITIVE()`.
 
@@ -783,7 +783,7 @@ Multi-part PAKE operations
         Identifier of the key holding the password or a value derived from the password.
         It must remain valid until the operation terminates.
         It must be of type :code:`PSA_KEY_TYPE_PASSWORD` or :code:`PSA_KEY_TYPE_PASSWORD_HASH`.
-        It must allow the usage :code:`PSA_KEY_USAGE_DERIVE`.
+        It must permit the usage :code:`PSA_KEY_USAGE_DERIVE`.
 
     .. return:: psa_status_t
     .. retval:: PSA_SUCCESS


### PR DESCRIPTION
* Describe the principle for `PSA_KEY_USAGE_EXPORT`: moving outside of current security domain
* Make the wording for each usage policy consistent
* Rewording the description to eliminate need for qualification of permission in some policies
* Replacing the word 'allow' with 'permit' in all policy enforcement descriptions, for consistency 