### PR TITLE
Clarify PSA_ALG_ECDSA_ANY policy requirements

### DIFF
--- a/doc/crypto/api/keys/policy.rst
+++ b/doc/crypto/api/keys/policy.rst
@@ -37,12 +37,12 @@ The following algorithm policies are supported:
 *   An algorithm built from `PSA_ALG_AT_LEAST_THIS_LENGTH_MAC()` allows any MAC algorithm from the same base class (for example, CMAC) which computes or verifies a MAC length greater than or equal to the length encoded in the wildcard algorithm.
 *   An algorithm built from `PSA_ALG_AEAD_WITH_AT_LEAST_THIS_LENGTH_TAG()` allows any AEAD algorithm from the same base class (for example, CCM) which computes or verifies a tag length greater than or equal to the length encoded in the wildcard algorithm.
 
-When a key is used in a cryptographic operation, the application must supply the algorithm to use for the operation. This algorithm is checked against the key's permitted algorithm policy.
+When a key is used in a cryptographic operation, the application must supply the algorithm to use for the operation. This algorithm is checked against the key's permitted-algorithm policy.
 
 .. function:: psa_set_key_algorithm
 
     .. summary::
-        Declare the permitted algorithm policy for a key.
+        Declare the permitted-algorithm policy for a key.
 
     .. param:: psa_key_attributes_t * attributes
         The attribute object to write to.
@@ -51,9 +51,9 @@ When a key is used in a cryptographic operation, the application must supply the
 
     .. return:: void
 
-    The permitted algorithm policy of a key encodes which algorithm or algorithms are permitted to be used with this key.
+    The permitted-algorithm policy of a key encodes which algorithm or algorithms are permitted to be used with this key.
 
-    This function overwrites any permitted algorithm policy previously set in ``attributes``.
+    This function overwrites any permitted-algorithm policy previously set in ``attributes``.
 
     .. admonition:: Implementation note
 
@@ -62,7 +62,7 @@ When a key is used in a cryptographic operation, the application must supply the
 .. function:: psa_get_key_algorithm
 
     .. summary::
-        Retrieve the permitted algorithm policy from key attributes.
+        Retrieve the permitted-algorithm policy from key attributes.
 
     .. param:: const psa_key_attributes_t * attributes
         The key attribute object to query.

--- a/doc/crypto/api/ops/aead.rst
+++ b/doc/crypto/api/ops/aead.rst
@@ -179,7 +179,7 @@ AEAD algorithms
 
         Unspecified if ``aead_alg`` is not a supported AEAD algorithm or if ``min_tag_length`` is less than ``1`` or too large for the specified AEAD algorithm.
 
-    A key with a minimum-tag-length AEAD wildcard algorithm as permitted algorithm policy can be used with all AEAD algorithms sharing the same base algorithm, and where the tag length of the specific algorithm is equal to or larger then the minimum tag length specified by the wildcard algorithm.
+    A key with a minimum-tag-length AEAD wildcard algorithm as permitted-algorithm policy can be used with all AEAD algorithms sharing the same base algorithm, and where the tag length of the specific algorithm is equal to or larger then the minimum tag length specified by the wildcard algorithm.
 
     .. note::
         When setting the minimum required tag length to less than the smallest tag length allowed by the base algorithm, this effectively becomes an 'any-tag-length-allowed' policy for that base algorithm.

--- a/doc/crypto/api/ops/algorithms.rst
+++ b/doc/crypto/api/ops/algorithms.rst
@@ -195,7 +195,7 @@ Algorithm categories
 
         This macro can return either ``0`` or ``1`` if ``alg`` is not a supported algorithm identifier.
 
-    Wildcard algorithm values can only be used to set the permitted algorithm field in a key policy, wildcard values cannot be used to perform an operation.
+    Wildcard algorithm values can only be used to set the permitted-algorithm field in a key policy, wildcard values cannot be used to perform an operation.
 
     See `PSA_ALG_ANY_HASH` for example of how a wildcard algorithm can be used in a key policy.
 

--- a/doc/crypto/api/ops/ka.rst
+++ b/doc/crypto/api/ops/ka.rst
@@ -28,7 +28,7 @@ Key agreement algorithms
 
     This algorithm can be used directly in a call to `psa_raw_key_agreement()`, or combined with a key derivation operation using `PSA_ALG_KEY_AGREEMENT()` for use with `psa_key_derivation_key_agreement()`.
 
-    When used as a key's permitted algorithm policy, the following uses are permitted:
+    When used as a key's permitted-algorithm policy, the following uses are permitted:
 
     *   In a call to `psa_raw_key_agreement()`, with algorithm `PSA_ALG_FFDH`.
     *   In a call to `psa_key_derivation_key_agreement()`, with any combined key agreement and key derivation algorithm constructed with `PSA_ALG_FFDH`.
@@ -51,7 +51,7 @@ Key agreement algorithms
 
     This algorithm can be used directly in a call to `psa_raw_key_agreement()`, or combined with a key derivation operation using `PSA_ALG_KEY_AGREEMENT()` for use with `psa_key_derivation_key_agreement()`.
 
-    When used as a key's permitted algorithm policy, the following uses are permitted:
+    When used as a key's permitted-algorithm policy, the following uses are permitted:
 
     *   In a call to `psa_raw_key_agreement()`, with algorithm `PSA_ALG_ECDH`.
     *   In a call to `psa_key_derivation_key_agreement()`, with any combined key agreement and key derivation algorithm constructed with `PSA_ALG_ECDH`.

--- a/doc/crypto/api/ops/macs.rst
+++ b/doc/crypto/api/ops/macs.rst
@@ -156,7 +156,7 @@ MAC algorithms
 
         Unspecified if ``mac_alg`` is not a supported MAC algorithm or if ``min_mac_length`` is less than ``1`` or too large for the specified MAC algorithm.
 
-    A key with a minimum-MAC-length MAC wildcard algorithm as permitted algorithm policy can be used with all MAC algorithms sharing the same base algorithm, and where the (potentially truncated) MAC length of the specific algorithm is equal to or larger then the wildcard algorithm's minimum MAC length.
+    A key with a minimum-MAC-length MAC wildcard algorithm as permitted-algorithm policy can be used with all MAC algorithms sharing the same base algorithm, and where the (potentially truncated) MAC length of the specific algorithm is equal to or larger then the wildcard algorithm's minimum MAC length.
 
     ..  note::
         When setting the minimum required MAC length to less than the smallest MAC length allowed by the base algorithm, this effectively becomes an 'any-MAC-length-allowed' policy for that base algorithm.

--- a/doc/crypto/api/ops/sign.rst
+++ b/doc/crypto/api/ops/sign.rst
@@ -796,7 +796,7 @@ Support macros
 
     This value must not be used to build other algorithms that are parametrized over a hash. For any valid use of this macro to build an algorithm ``alg``, :code:`PSA_ALG_IS_HASH_AND_SIGN(alg)` is true.
 
-    This value cannot be used to build an algorithm specification to perform an operation. If used in this way, the operation wil fail with an error.
+    This value cannot be used to build an algorithm specification to perform an operation. If used in this way, the operation will fail with an error.
 
     .. rubric:: Usage
 

--- a/doc/crypto/api/ops/sign.rst
+++ b/doc/crypto/api/ops/sign.rst
@@ -202,6 +202,8 @@ Asymmetric signature algorithms
 
     This algorithm is only recommended to sign or verify a sequence of bytes that are an already-calculated hash. Note that the input is padded with zeros on the left or truncated on the right as required to fit the curve size.
 
+    This algorithm cannot be used with the wildcard key policy :code:`PSA_ALG_ECDSA(PSA_ALG_ANY_HASH)`. It is only permitted when `PSA_ALG_ECDSA_ANY` is the key's permitted-algorithm policy.
+
     .. subsection:: Compatible key types
 
         | :code:`PSA_KEY_TYPE_ECC_KEY_PAIR(family)`
@@ -789,12 +791,12 @@ Support macros
     .. summary::
         When setting a hash-and-sign algorithm in a key policy, permit any hash algorithm.
 
-    This value can be used to form the permitted algorithm attribute of a key policy for a signature algorithm that is parametrized by a hash. A key with this policy can then be used to perform operations using the same signature algorithm parametrized with any supported hash.
+    This value can be used to form the permitted-algorithm attribute of a key policy for a signature algorithm that is parametrized by a hash. A key with this policy can then be used to perform operations using the same signature algorithm parametrized with any supported hash.
     A signature algorithm created using this macro is a wildcard algorithm, and `PSA_ALG_IS_WILDCARD()` will return true.
 
     This value must not be used to build other algorithms that are parametrized over a hash. For any valid use of this macro to build an algorithm ``alg``, :code:`PSA_ALG_IS_HASH_AND_SIGN(alg)` is true.
 
-    This value must not be used to build an algorithm specification to perform an operation. It is only valid for setting the permitted algorithm in a key policy.
+    This value cannot be used to build an algorithm specification to perform an operation. If used in this way, the operation wil fail with an error.
 
     .. rubric:: Usage
 

--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -23,6 +23,7 @@ Clarifications and fixes
 *   Clarify the requirements on the ``hash`` parameter in the `psa_sign_hash()` and `psa_verify_hash()` functions.
 *   Explicitly describe the handling of input and output in `psa_cipher_update()`, consistent with the documentation of `psa_aead_update()`.
 *   Clarified the behavior of operation objects following a call to a setup function. Provided a diagram to illustrate :ref:`multi-part operation states <multi-part-operations>`.
+*   Clarify the key policy requirement for `PSA_ALG_ECDSA_ANY`.
 
 Other changes
 ~~~~~~~~~~~~~

--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -50,7 +50,7 @@ Changes between *1.0.1* and *1.1.0*
 Changes to the API
 ~~~~~~~~~~~~~~~~~~
 
-*   Relaxation when a raw key agreement is used as a key's permitted algorithm policy. This now also permits the key agreement to be combined with any key derivation algorithm. See `PSA_ALG_FFDH` and `PSA_ALG_ECDH`.
+*   Relaxation when a raw key agreement is used as a key's permitted-algorithm policy. This now also permits the key agreement to be combined with any key derivation algorithm. See `PSA_ALG_FFDH` and `PSA_ALG_ECDH`.
 
 *   Provide wildcard permitted-algorithm polices for MAC and AEAD that can specify a minimum MAC or tag length. The following elements are added to the API:
 

--- a/headers/crypto/1.1/psa/crypto.h
+++ b/headers/crypto/1.1/psa/crypto.h
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 /* This file is a reference template for implementation of the
- * PSA Certified Crypto API v1.1.1
+ * PSA Certified Crypto API v1.1
  */
 
 #ifndef PSA_CRYPTO_H
@@ -584,7 +584,7 @@ psa_key_id_t psa_get_key_id(const psa_key_attributes_t * attributes);
 typedef uint32_t psa_algorithm_t;
 
 /**
- * @brief Declare the permitted algorithm policy for a key.
+ * @brief Declare the permitted-algorithm policy for a key.
  * 
  * @param attributes The attribute object to write to.
  * @param alg        The permitted algorithm to write.
@@ -593,7 +593,7 @@ void psa_set_key_algorithm(psa_key_attributes_t * attributes,
                            psa_algorithm_t alg);
 
 /**
- * @brief Retrieve the permitted algorithm policy from key attributes.
+ * @brief Retrieve the permitted-algorithm policy from key attributes.
  * 
  * @param attributes The key attribute object to query.
  * 


### PR DESCRIPTION
In particular, it does not follow the pattern of `PSA_ALG_RSA_PKCS1V15_SIGN_RAW`