### PR TITLE
Remove URLs for CSTC standards

### DIFF
--- a/doc/crypto/api/keys/types.rst
+++ b/doc/crypto/api/keys/types.rst
@@ -344,7 +344,7 @@ Symmetric keys
 
     For the XTS block cipher mode (`PSA_ALG_XTS`), the SM4 key size is 256 bits (two 16-byte keys).
 
-    The SM4 block cipher is defined in :cite-title:`CSTC0002` (English version :cite:`CSTC0002/E`).
+    The SM4 block cipher is defined in :cite-title:`CSTC0002`.
 
     .. subsection:: Compatible algorithms
 

--- a/doc/crypto/api/ops/hashes.rst
+++ b/doc/crypto/api/ops/hashes.rst
@@ -183,7 +183,7 @@ Hash algorithms
     .. summary::
         The SM3 message-digest algorithm.
 
-    SM3 is defined in :cite-title:`ISO10118`, and also in :cite-title:`CSTC0004` (English version :cite:`CSTC0004/E`).
+    SM3 is defined in :cite-title:`ISO10118`, and also in :cite-title:`CSTC0004`.
 
 Single-part hashing functions
 -----------------------------

--- a/doc/crypto/references
+++ b/doc/crypto/references
@@ -313,25 +313,11 @@
     :title: GM/T 0002-2012: SM4 block cipher algorithm
     :author: Cryptography Standardization Technical Committee
     :publication: March 2012
-    :url: http://www.gmbz.org.cn/main/viewfile/20180108015408199368.html
-
-.. reference:: CSTC0002/E
-    :title: GM/T 0002-2012: SM4 block cipher algorithm
-    :author: Cryptography Standardization Technical Committee
-    :publication: April 2018 (English version)
-    :url: http://www.gmbz.org.cn/main/postDetail.html?id=20180404044052
 
 .. reference:: CSTC0004
     :title: GM/T 0004-2012: SM3 cryptographic hash algorithm
     :author: Cryptography Standardization Technical Committee
     :publication: March 2012
-    :url: http://www.gmbz.org.cn/main/viewfile/20180108023812835219.html
-
-.. reference:: CSTC0004/E
-    :title: GM/T 0004-2012: SM3 cryptographic hash algorithm
-    :author: Cryptography Standardization Technical Committee
-    :publication: July 2018 (English version)
-    :url: http://www.gmbz.org.cn/main/postDetail.html?id=20180724105928
 
 .. reference:: X9-62
     :title: Public Key Cryptography For The Financial Services Industry: The Elliptic Curve Digital Signature Algorithm (ECDSA)


### PR DESCRIPTION
The location of documents published by CSTC changes from time to time. It is unhelpful to provide an obsolete URL with the citation reference.