### PR TITLE
Explicitly set longtable attribute for tables that can or must split across pages

### DIFF
--- a/doc/attestation/appendix/history.rst
+++ b/doc/attestation/appendix/history.rst
@@ -7,6 +7,7 @@ Document history
 ================
 
 ..  list-table::
+    :class: longtable
     :header-rows: 1
     :widths: 3 17
 

--- a/doc/attestation/overview/report.rst
+++ b/doc/attestation/overview/report.rst
@@ -14,6 +14,7 @@ Information model
 The following table describes the mandatory and optional claims in the report:
 
 ..  list-table::
+   :class: longtable
    :header-rows: 1
    :widths: 20 15 50
 

--- a/doc/crypto/api/keys/lifetimes.rst
+++ b/doc/crypto/api/keys/lifetimes.rst
@@ -103,6 +103,7 @@ Lifetime encodings
 
     .. list-table:: Key persistence level values
         :name: persistence-levels
+        :class: longtable
         :header-rows: 1
         :widths: 2,3
         :align: left
@@ -152,6 +153,7 @@ Lifetime encodings
 
     .. list-table:: Key location indicator values
         :name: location-indicators
+        :class: longtable
         :header-rows: 1
         :widths: 1,3
         :align: left

--- a/doc/crypto/api/library/status.rst
+++ b/doc/crypto/api/library/status.rst
@@ -48,6 +48,7 @@ Common error codes
 Some of the common status codes have a more precise meaning when returned by a function in the |API|, compared to the definitions in `[PSA-STAT]`.
 
 .. list-table::
+    :class: longtable
     :header-rows: 1
     :widths: 1 2
 

--- a/doc/crypto/api/ops/kdf.rst
+++ b/doc/crypto/api/ops/kdf.rst
@@ -790,6 +790,7 @@ Key derivation functions
 
     .. list-table:: Standard key derivation process
         :name: std-key-derivation
+        :class: longtable
         :header-rows: 1
         :widths: 2,5
 

--- a/doc/crypto/appendix/sra.rst
+++ b/doc/crypto/appendix/sra.rst
@@ -97,6 +97,7 @@ Cryptography is used as a mitigation to the risk of disclosure or tampering with
 
 .. list-table:: Security goals
     :name: table-sg
+    :class: longtable
     :header-rows: 1
     :widths: 1,9
 
@@ -129,6 +130,7 @@ A specific implementation of the |API| might not include all of these adversaria
 
 .. list-table:: Adversarial models
     :name: table-adversaries
+    :class: longtable
     :header-rows: 1
     :widths: 1,9
 
@@ -168,6 +170,7 @@ Adversarial models that are outside the scope of this assessment are shown in :n
 
 .. list-table:: Adversarial models that are outside the scope of this SRA
     :name: table-out-of-scope-adversaries
+    :class: longtable
     :header-rows: 1
     :widths: 1,9
 
@@ -194,6 +197,7 @@ See :secref:`risk-assessment` for an evaluation of the risks posed by these thre
 
 .. list-table:: Threats and attacks
     :name: table-threats
+    :class: longtable
     :header-rows: 2
     :widths: 2,5,2,2,14
 
@@ -310,6 +314,7 @@ It is recommended that this assessment is repeated for a specific implementation
 
 .. list-table:: Risk assessment
     :name: table-risks
+    :class: longtable
     :header-rows: 1
     :widths: 1,1,1,1,1
 
@@ -393,6 +398,7 @@ The objectives in :numref:`table-objectives` are a high-level description of wha
 
 .. list-table:: Mitigation objectives
     :name: table-objectives
+    :class: longtable
     :header-rows: 1
     :widths: 1,7,5
 
@@ -443,6 +449,7 @@ The design of the API can mitigate, or enable a cryptoprocessor to mitigate, som
 
 .. list-table:: Security requirements
     :name: tab-security-requirements
+    :class: longtable
     :header-rows: 1
     :widths: 1,4,4,4
 
@@ -541,6 +548,7 @@ Implementation remediations
 
 .. list-table:: Implementation remediations
     :name: tab-remediation
+    :class: longtable
     :header-rows: 1
     :widths: 1,4,8
 
@@ -604,6 +612,7 @@ Threats T.2-T.4, and T.7-T.9 are fully mitigated in the API design, as described
 
 .. list-table:: Residual risk
     :name: tab-residual-risk
+    :class: longtable
     :header-rows: 1
     :widths: 1,4,8
 

--- a/doc/ext-pake/overview/intro.rst
+++ b/doc/ext-pake/overview/intro.rst
@@ -124,6 +124,7 @@ Some schemes like that are:
 
 .. list-table::
     :header-rows: 1
+    :class: longtable
     :widths: auto
     :align: left
 

--- a/doc/fwu/overview/programming-model.rst
+++ b/doc/fwu/overview/programming-model.rst
@@ -51,6 +51,7 @@ Component state
 
 .. list-table:: Component states
    :name: tab-states
+   :class: longtable
    :header-rows: 1
    :widths: 1 6
 
@@ -182,6 +183,7 @@ The complexity of the state model is a response to the requirements that follow 
 
 .. list-table:: Use case implications for the state model
    :name: tab-model-rationale
+   :class: longtable
    :header-rows: 1
    :widths: 1 3
 

--- a/doc/storage/appendix/history.rst
+++ b/doc/storage/appendix/history.rst
@@ -7,6 +7,7 @@ Document history
 ================
 
 ..  list-table::
+    :class: longtable
     :header-rows: 1
     :widths: 3 3 14
 

--- a/doc/storage/overview/architecture.rst
+++ b/doc/storage/overview/architecture.rst
@@ -87,6 +87,7 @@ In the event of power failure or other interruption of operations that modify st
 
 .. list-table:: Properties of storage operations
    :name: tab-acid
+   :class: longtable
    :stub-columns: 1
    :widths: 1 5
 
@@ -110,6 +111,7 @@ Components
 
 .. list-table:: Components in a system that implements the Trusted Storage API
    :name: tab-components
+   :class: longtable
    :header-rows: 1
    :widths: 1 3
 


### PR DESCRIPTION
This is required for the tooling update for Sphinx 5.3, and has no effect on the output with earlier tooling.

(Earlier tooling created booktabs-style tables by overriding some of the Sphinx handling, which set the 'longtable' class on the tables. The Sphinx v5.3 update of the tools now uses the built-in booktabs support, and these tables need to set 'longtable' in the source)