### PR TITLE
Prepare crypto 1.1.2

### DIFF
--- a/doc/crypto/api.db/psa/crypto.h
+++ b/doc/crypto/api.db/psa/crypto.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2018-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-FileCopyrightText: Copyright 2018-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 // SPDX-License-Identifier: Apache-2.0
 
 typedef /* implementation-defined type */ psa_aead_operation_t;

--- a/doc/crypto/api/keys/management.rst
+++ b/doc/crypto/api/keys/management.rst
@@ -527,6 +527,7 @@ This section defines the format of the key data that an implementation is requir
 
 .. list-table:: Standard key formats
     :name: std-key-formats
+    :class: longtable
     :header-rows: 1
     :widths: 2,5
 

--- a/doc/crypto/api/library/library.rst
+++ b/doc/crypto/api/library/library.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2018-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2018-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 |API| library

--- a/doc/crypto/api/library/status.rst
+++ b/doc/crypto/api/library/status.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2018-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2018-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. _status-codes:

--- a/doc/crypto/api/ops/sign.rst
+++ b/doc/crypto/api/ops/sign.rst
@@ -474,7 +474,9 @@ Asymmetric signature functions
     .. param:: psa_algorithm_t alg
         An asymmetric signature algorithm that separates the hash and sign operations: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_SIGN_HASH(alg)` is true.
     .. param:: const uint8_t * hash
-        The input to sign. This is usually the hash of a message. See the detailed description of this function and the description of individual signature algorithms for a detailed description of acceptable inputs.
+        The input to sign. This is usually the hash of a message.
+
+        See the description of this function, or the description of individual signature algorithms, for details of the acceptable inputs.
     .. param:: size_t hash_length
         Size of the ``hash`` buffer in bytes.
     .. param:: uint8_t * signature
@@ -547,7 +549,9 @@ Asymmetric signature functions
     .. param:: psa_algorithm_t alg
         An asymmetric signature algorithm that separates the hash and sign operations: a value of type `psa_algorithm_t` such that :code:`PSA_ALG_IS_SIGN_HASH(alg)` is true.
     .. param:: const uint8_t * hash
-        The input whose signature is to be verified. This is usually the hash of a message. See the detailed description of this function and the description of individual signature algorithms for a detailed description of acceptable inputs.
+        The input whose signature is to be verified. This is usually the hash of a message.
+
+        See the description of this function, or the description of individual signature algorithms, for details of the acceptable inputs.
     .. param:: size_t hash_length
         Size of the ``hash`` buffer in bytes.
     .. param:: const uint8_t * signature

--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -14,9 +14,6 @@ This section provides the detailed changes made between published version of the
 Changes between *1.1.1* and *1.1.2*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Changes to the API
-~~~~~~~~~~~~~~~~~~
-
 Clarifications and fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/crypto/conf.py
+++ b/doc/crypto/conf.py
@@ -30,7 +30,7 @@ doc_info = {
     'issue_no': 2,
     # Identifies the sequence number of a release candidate of the same issue
     # default to None
-    'release_candidate': 1,
+    'release_candidate': None,
     # Draft status - use this to indicate the document is not ready for publication
     #'draft': True,
 
@@ -43,7 +43,7 @@ doc_info = {
     'license': 'psa-certified-api-license',
 
     # Document date, default to build date
-    #'date': '17/10/2022',
+    'date': '23/03/2022',
 
     # Default header file for API definitions
     # default to None, and can be set in documentation source

--- a/doc/crypto/conf.py
+++ b/doc/crypto/conf.py
@@ -30,9 +30,9 @@ doc_info = {
     'issue_no': 2,
     # Identifies the sequence number of a release candidate of the same issue
     # default to None
-    'release_candidate': None,
+    'release_candidate': 1,
     # Draft status - use this to indicate the document is not ready for publication
-    'draft': True,
+    #'draft': True,
 
     # Arm document confidentiality. Must be either Non-confidential or Confidential
     # Marked as open issue if not provided
@@ -43,7 +43,7 @@ doc_info = {
     'license': 'psa-certified-api-license',
 
     # Document date, default to build date
-    'date': '17/10/2022',
+    #'date': '17/10/2022',
 
     # Default header file for API definitions
     # default to None, and can be set in documentation source

--- a/doc/crypto/releases
+++ b/doc/crypto/releases
@@ -46,3 +46,9 @@
     Relicensed as open source under CC BY-SA 4.0.
 
     Improve support for TLS.
+
+.. release:: 1.1.2 Final
+    :date: March 2023
+    :confidentiality: Non-confidential
+
+    Clarifications and fixes

--- a/headers/crypto/1.1/psa/crypto.h
+++ b/headers/crypto/1.1/psa/crypto.h
@@ -1594,7 +1594,8 @@ psa_status_t psa_cipher_update(psa_cipher_operation_t * operation,
  * @brief Finish encrypting or decrypting a message in a cipher operation.
  *
  * @param operation     Active cipher operation.
- * @param output        Buffer where the output is to be written.
+ * @param output        Buffer where the last part of the output is to be
+ *                      written.
  * @param output_size   Size of the output buffer in bytes.
  * @param output_length On success, the number of bytes that make up the
  *                      returned output.


### PR DESCRIPTION
Finalize Crypto API 1.1.2 prior to publication

This includes a number of minor fixes, clarifications, and document improvements for v1.1

Preview of the final specification for review/comment: [IHI0086-PSA_Certified_Crypto_API-1.1.2-rc1.pdf](https://github.com/ARM-software/psa-api/files/10981250/IHI0086-PSA_Certified_Crypto_API-1.1.2-rc1.pdf)
