### PR TITLE
Update links to FF-M, tidy up PSA API references

### DIFF
--- a/doc/attestation/about.rst
+++ b/doc/attestation/about.rst
@@ -70,10 +70,10 @@
     :doc_no: ARM IHI 0097
     :url: arm-software.github.io/psa-api/status-code
 
-.. reference:: PSA-FF-M
+.. reference:: PSA-FFM
     :title: Arm® Platform Security Architecture Firmware Framework
     :doc_no: ARM DEN 0063
-    :url: pages.arm.com/psa-apis
+    :url: developer.arm.com/documentation/den0063
 
 .. reference:: C99
     :title: ISO/IEC 9899:1999 --- Programming Languages --- C

--- a/doc/attestation/api/api.rst
+++ b/doc/attestation/api/api.rst
@@ -36,7 +36,7 @@ Status codes
 
 The |API| uses the status code definitions that are shared with the other PSA Certified APIs.
 
-The following elements are defined in :file:`psa/error.h` from :cite-title:`PSA-STAT` (previously defined in :cite:`PSA-FF-M`):
+The following elements are defined in :file:`psa/error.h` from :cite-title:`PSA-STAT` (previously defined in :cite:`PSA-FFM`):
 
 .. code-block:: xref
 

--- a/doc/attestation/overview/report.rst
+++ b/doc/attestation/overview/report.rst
@@ -47,7 +47,7 @@ The following table describes the mandatory and optional claims in the report:
       -  Uniquely identifies the underlying :term:`Immutable Platform Root of Trust`. A verification service can use this claim to locate the details of the verification process. Such details include the implementation's origin and associated certification state. The full definition is in `[PSM]`.
    *  -  Client ID
       -  Yes
-      -  Represents the Partition ID of the caller. It is a signed integer whereby negative values represent callers from the :term:`NSPE` and where positive IDs represent callers from the :term:`SPE`. The value ``0`` is not permitted. The full definition of a Partition ID is provided by :cite-title:`PSA-FF-M`.
+      -  Represents the Partition ID of the caller. It is a signed integer whereby negative values represent callers from the :term:`NSPE` and where positive IDs represent callers from the :term:`SPE`. The value ``0`` is not permitted. The full definition of a Partition ID is provided by :cite-title:`PSA-FFM`.
 
          It is essential that this claim is checked in the verification process to ensure that a security domain cannot spoof a report from another security domain.
    *  -  Security Lifecycle

--- a/doc/crypto/references
+++ b/doc/crypto/references
@@ -14,7 +14,7 @@
 .. reference:: PSA-FFM
     :title: Arm® Platform Security Architecture Firmware Framework
     :doc_no: ARM DEN 0063
-    :url: pages.arm.com/psa-apis
+    :url: developer.arm.com/documentation/den0063
 
 .. reference:: PSA-STAT
     :title: PSA Certified Status code API

--- a/doc/fwu/references
+++ b/doc/fwu/references
@@ -9,12 +9,7 @@
 .. reference:: PSA-FFM
     :title: Arm® Platform Security Architecture Firmware Framework
     :doc_no: ARM DEN 0063
-    :url: pages.arm.com/psa-apis
-
-.. reference:: PSA-SS
-    :title: PSA Certified Secure Storage API
-    :doc_no: ARM IHI 0087
-    :url: arm-software.github.io/psa-api/storage
+    :url: developer.arm.com/documentation/den0063
 
 .. reference:: PSM
    :title: Platform Security Model

--- a/doc/status-code/references
+++ b/doc/status-code/references
@@ -4,7 +4,7 @@
 .. reference:: PSA-FFM
     :title: Arm® Platform Security Architecture Firmware Framework
     :doc_no: DEN 0063
-    :url: pages.arm.com/psa-apis.html
+    :url: developer.arm.com/documentation/den0063.html
 
 .. reference:: TF-M
     :title: Trusted Firmware-M

--- a/doc/storage/about.rst
+++ b/doc/storage/about.rst
@@ -58,10 +58,10 @@
     :doc_no: ARM IHI 0097
     :url: arm-software.github.io/psa-api/status-code
 
-.. reference:: PSA-FF-M
+.. reference:: PSA-FFM
     :title: Arm® Platform Security Architecture Firmware Framework
     :doc_no: ARM DEN 0063
-    :url: pages.arm.com/psa-apis
+    :url: developer.arm.com/documentation/den0063
 
 
 .. Glossary terms used in this specification

--- a/doc/storage/api/api.rst
+++ b/doc/storage/api/api.rst
@@ -9,7 +9,7 @@ Status codes
 
 The |API| uses the status code definitions that are shared with the other PSA Certified APIs.
 
-The following elements are defined in :file:`psa/error.h` from :cite-title:`PSA-STAT` (previously defined in :cite:`PSA-FF-M`):
+The following elements are defined in :file:`psa/error.h` from :cite-title:`PSA-STAT` (previously defined in :cite:`PSA-FFM`):
 
 .. code-block:: xref
 

--- a/doc/storage/overview/architecture.rst
+++ b/doc/storage/overview/architecture.rst
@@ -66,7 +66,7 @@ UIDs
 
 ``uids`` in the |API| are defined as ``uint64_t``. This is expected to be larger than would be used on any system. This large namespace is chosen to allow a :term:`Root of Trust Service` to easily manage assets on behalf of other services.
 
-For example, consider a cryptography service running as a RoT Service. When a service running in a :term:`Secure Partition` requests key storage from the cryptography service, the cryptography service can concatenate a numerical identity of the requesting partition (for example, a ``int32_t`` in the :cite-title:`PSA-FF-M`) with the key identifier (for example, a ``uint32_t`` in the :cite-title:`PSA-CRYPT`) to generate the ``uid`` of the Internal Trusted Storage entry for the key. This allows the cryptography service to easily manage isolation between the key namespaces of its various clients.
+For example, consider a cryptography service running as a RoT Service. When a service running in a :term:`Secure Partition` requests key storage from the cryptography service, the cryptography service can concatenate a numerical identity of the requesting partition (for example, a ``int32_t`` in the :cite-title:`PSA-FFM`) with the key identifier (for example, a ``uint32_t`` in the :cite-title:`PSA-CRYPT`) to generate the ``uid`` of the Internal Trusted Storage entry for the key. This allows the cryptography service to easily manage isolation between the key namespaces of its various clients.
 
 Requirements for ``uid``:
 

--- a/doc/storage/overview/requirements.rst
+++ b/doc/storage/overview/requirements.rst
@@ -41,4 +41,4 @@ Internal Trusted Storage requirements
 14. The `PSA_STORAGE_FLAG_WRITE_ONCE` must be enforced when the Root of Trust Lifecycle state of the device is ``SECURED``  or ``NON_PSA_ROT_DEBUG``. It must not be enforced when the device is in the ``PSA_ROT_PROVISIONING`` state.
 15. The creation of a ``uid`` with value ``0`` (zero) must be treated as an error.
 
-The lifecycle states are described in :cite-title:`PSM` and :cite-title:`PSA-FF-M`.
+The lifecycle states are described in :cite-title:`PSM` and :cite-title:`PSA-FFM`.


### PR DESCRIPTION
The Firmware Framework for M specification has been moved to developer.arm.com, and the citation reference was inconsistent across the specifications.