### PR TITLE
Clarifications prior to release

### DIFF
--- a/doc/fwu/about.rst
+++ b/doc/fwu/about.rst
@@ -19,19 +19,15 @@
    .. reference-table:: Documents referenced by this document
       :sorted:
 
-.. current-status::
-
-   This document is at Beta quality status which has a particular meaning to Arm of which the recipient must be aware.
-   A Beta quality specification will be sufficiently stable & committed for initial product development, however all aspects of the architecture described herein remain SUBJECT TO CHANGE.
-   Please ensure that you have the latest revision.
-
 .. potential-for-change::
+
+   The contents of this specification are stable for version |docversion|.
 
    The following may change in updates to the version |docversion| specification:
 
-   *  Important API changes required before issuing a final v1.0.0 specification.
-   *  Optional feature additions.
-   *  Corrections and additions to the informative chapters, use cases and examples.
+   *  Small optional feature additions.
    *  Clarifications.
+
+   Significant additions, or any changes that affect the compatibility of the interfaces defined in this specification will only be included in a new major or minor version of the specification.
 
 .. about::

--- a/doc/fwu/appendix/change-history.rst
+++ b/doc/fwu/appendix/change-history.rst
@@ -11,10 +11,10 @@ Changes between version *1.0 Beta* and *1.0.0*
 
 .. rubric:: General changes
 
-*  Clarified the definition of 'volatile staging' and relaxed the requirements for 'non-volatile staging'
+*  Clarified the definition of :term:`volatile staging` and relaxed the requirements for non-volatile staging.
 
    -  Defined the effects of the `PSA_FWU_FLAG_VOLATILE_STAGING` flag.
-   -  Permitted the volatility of the WRITING, FAILED, and UPDATED states to be :sc:`implementation defined` when the CANDIDATE state is persistent.
+   -  Permitted the volatility of the WRITING, FAILED, and UPDATED states to be :scterm:`implementation defined` when the CANDIDATE state is not volatile.
    -  Defined the impact on the state transitions when these states are volatile.
    -  Added additional example state model diagrams for components with volatile staging.
    -  See :secref:`state-model`, :secref:`volatile-states`, and :secref:`variations`.

--- a/doc/fwu/appendix/variations.rst
+++ b/doc/fwu/appendix/variations.rst
@@ -103,7 +103,7 @@ The simplified flow is shown in :numref:`fig-states-no-reboot-no-trial`:
 .. _variations-volatile:
 
 Component with volatile staging
--------------------------------------
+-------------------------------
 
 A component that has the `PSA_FWU_FLAG_VOLATILE_STAGING` flag set in the information reported by `psa_fwu_query()`, does not maintain the WRITING, CANDIDATE, FAILED, and UPDATED component states across a reboot.
 

--- a/doc/fwu/appendix/variations.rst
+++ b/doc/fwu/appendix/variations.rst
@@ -20,22 +20,24 @@ An implementation is also permitted to provide either volatile or persistent beh
    :widths: 2 2 2 5
 
    Reboot required, Trial required, Staging type :sup:`a`, Description
-   Yes, Yes, Persistent, See :ref:`complete model <state-transitions>`
+   Yes, Yes, Non-volatile, See :ref:`complete model <state-transitions>`
    Yes, Yes, Volatile, See :ref:`complete model with volatile staging <fig-states-volatile>`
-   Yes, No, Persistent, See :ref:`no-trial model <states-reboot-no-trial>`
+   Yes, No, Non-volatile, See :ref:`no-trial model <states-reboot-no-trial>`
    Yes, No, Volatile, See :ref:`no-trial model with volatile staging <fig-states-no-trial-volatile>`
-   No, Yes, Persistent, See :ref:`no-reboot model <states-no-reboot-trial>`
+   No, Yes, Non-volatile, See :ref:`no-reboot model <states-no-reboot-trial>`
    No, Yes, Volatile, See :ref:`no-reboot model with volatile staging <fig-states-no-reboot-volatile>`
-   No, No, Persistent, See :ref:`basic state model <states-no-reboot-no-trial>`
+   No, No, Non-volatile, See :ref:`basic state model <states-no-reboot-no-trial>`
    No, No, Volatile, See :ref:`basic state model with volatile staging <fig-states-no-reboot-no-trial-volatile>`
 
 a)
-   If the staging type is persistent, then CANDIDATE state is persistent, and it is :scterm:`implementation defined` whether WRITING, FAILED, and UPDATED states are persistent.
+   If the staging type is volatile, then CANDIDATE, WRITING, FAILED, and UPDATED states are volatile.
 
-Component with persistent staging
----------------------------------
+   If the staging type is non-volatile, then CANDIDATE state is non-volatile, and it is :scterm:`implementation defined` whether WRITING, FAILED, and UPDATED states are volatile.
 
-A component that does not have the `PSA_FWU_FLAG_VOLATILE_STAGING` flag set in the information reported by `psa_fwu_query()`, will maintain the CANDIDATE component state across a reboot, and can optionally maintain the WRITING, FAILED, adn UPDATED component states across a reboot.
+Component with non-volatile staging
+-----------------------------------
+
+A component that does not have :term:`volatile staging` will maintain the CANDIDATE component state across a reboot, and can optionally maintain the WRITING, FAILED, and UPDATED component states across a reboot.
 
 *  Additional reboot transitions for states with optional volatility are indicated with '†' and '‡' marks on the state, and described in the figure legend.
 
@@ -105,13 +107,13 @@ The simplified flow is shown in :numref:`fig-states-no-reboot-no-trial`:
 Component with volatile staging
 -------------------------------
 
-A component that has the `PSA_FWU_FLAG_VOLATILE_STAGING` flag set in the information reported by `psa_fwu_query()`, does not maintain the WRITING, CANDIDATE, FAILED, and UPDATED component states across a reboot.
+A component that has :term:`volatile staging` does not maintain the WRITING, CANDIDATE, FAILED, and UPDATED component states across a reboot.
 
-In each case the state model is very similar to the associated state model for a component with persistent staging, except that a reboot now affects almost all states:
+In each case the state model is very similar to the associated state model for a component with non-volatile staging, except that a reboot now affects almost all states:
 
 *  WRITING, CANDIDATE, and FAILED states will always revert to READY, discarding any image that had been prepared or rejected.
 *  UPDATED state is progressed to READY.
-*  Existing reboot transitions from STAGED, TRIAL, and REJECTED, that go to FAILED in the persistent-staging model, are reverted to READY.
+*  Existing reboot transitions from STAGED, TRIAL, and REJECTED, that go to FAILED in the non-volatile-staging model, are reverted to READY.
 *  The existing reboot transition from STAGED to UPDATED for a successful installation in the 'no trial' model, transitions to READY.
 
 The modified flows are shown in the following figures:

--- a/doc/fwu/conf.py
+++ b/doc/fwu/conf.py
@@ -30,7 +30,7 @@ doc_info = {
     'issue_no': 0,
     # Identifies the sequence number of a release candidate of the same issue
     # default to None
-    'release_candidate': None,
+    #'release_candidate': 2,
     'draft': True,
 
     # Arm document confidentiality. Must be either Non-confidential or Confidential
@@ -42,7 +42,7 @@ doc_info = {
     'license': 'psa-certified-api-license',
 
     # Document date, default to build date
-    'date': '17/10/2022',
+    'date': '31/7/2022',
 
 
     # psa_spec: default header file for API definitions
@@ -75,18 +75,6 @@ doc_info = {
 
 # absolute or relative path to the psa_spec material from this file
 atg_sphinx_spec_dir = '../atg-sphinx-spec'
-
-# If the draft flag is set, then include extra content and watermark
-
-if doc_info.get('draft'):
-    doc_info.pop('date', None)                      # Remove any release date - use build date
-    doc_info['include_content'] = ['rationale', 'todo', 'banner']
-    doc_info['watermark'] = "DRAFT"
-
-# If a release candidate, then include watermark
-
-if doc_info.get('release_candidate'):
-    doc_info['watermark'] = "Candidate"
 
 # Set up and run the atg-sphinx-spec configuration
 

--- a/doc/fwu/index.rst
+++ b/doc/fwu/index.rst
@@ -23,18 +23,6 @@
    overview/programming-model
    api/api
 
-..
-   maintoc::
-
-   intro
-   goals
-   terminology
-   security
-   design
-   api
-
-
-
 ..  appendix::
 
    appendix/example-header

--- a/doc/fwu/overview/architecture.rst
+++ b/doc/fwu/overview/architecture.rst
@@ -97,6 +97,8 @@ The update service is a software component that stores a firmware image in devic
 
 Depending on the system design, the installation process can be implemented within the update service, or it can be implemented within a bootloader or other system component.
 
+.. _arch-firmware-store:
+
 Firmware store
 ^^^^^^^^^^^^^^
 
@@ -104,7 +106,7 @@ The firmware store is the location where firmware images are stored. Conceptuall
 
 The |API| presents a separate firmware store for each component. Each component's firmware store can have one or more images present. The state of the firmware store determines how those images are used, and what is required to proceed with a firmware update.
 
-The "staging area" is a region within a firmware store used for a firmware image that is being transferred to the device. Once transfer is complete, the image in the staging area can be verified during installation.
+The :term:`staging area` is a region within a firmware store used for a firmware image that is being transferred to the device. Once transfer is complete, the image in the staging area can be verified during installation.
 
 Bootloader
 ^^^^^^^^^^

--- a/doc/fwu/overview/architecture.rst
+++ b/doc/fwu/overview/architecture.rst
@@ -102,7 +102,7 @@ Depending on the system design, the installation process can be implemented with
 Firmware store
 ^^^^^^^^^^^^^^
 
-The firmware store is the location where firmware images are stored. Conceptually the Firmware store is shared between the update service and the bootloader. Both components share access to the firmware store to manage the firmware update process.
+The firmware store is the location where firmware images are stored. Conceptually the firmware store is shared between the update service and the bootloader. Both components share access to the firmware store to manage the firmware update process.
 
 The |API| presents a separate firmware store for each component. Each component's firmware store can have one or more images present. The state of the firmware store determines how those images are used, and what is required to proceed with a firmware update.
 
@@ -174,7 +174,7 @@ Untrusted client
 
 In this architecture, part of the update service must run as a service within the PRoT, to query and update the firmware store. The update client accesses this service via an update service proxy library, which implements the |API|.
 
-The |API| is designed for implementation across a security boundary, as used in this architecture.
+The |API| is designed for implementation across a security boundary, as used in this architecture. The interface between the update service proxy and the update service itself is :scterm:`implementation defined`.
 
 This architecture enables all of the firmware verification requirements to be fulfilled by the update service within the PRoT.
 
@@ -210,12 +210,12 @@ Trusted client
 
    Implementation architecture with a trusted update client
 
-In this architecture, it is possible for verification of an update to happen in any component, including the update client itself. This approach can be suitable for highly constrained devices, and relies on the security provided by the protocol used between the update server and update client.
+In this architecture, it is permitted for verification of an update to happen in any component, including the update client itself. This approach can be suitable for highly constrained devices, and relies on the security provided by the protocol used between the update server and update client.
 
 .. warning::
 
    If the implementation assumes that manifests and firmware images provided by the client are valid, and carries out the preparation and installation without further verification, then the |API| is being used purely as a hardware abstraction layer (HAL) for the firmware store.
 
-   An implementation like this must clearly document this assumption to ensure update clients carry out sufficient verification of firmware images before calling the |API|.
+   An implementation like this must clearly document this assumption to ensure update clients carry out sufficient verification of firmware manifests, firmware images, and firmware dependencies before calling the |API|.
 
-This implementation architecture can also be used in a device that does not enforce a :term:`secure boot` policy. For example, this can enable code reuse by using a single API for firmware update across devices that have different security requirements and policies. Although permitted by the |API|, this usage is not a focus for the specification.
+This implementation architecture can also be used in a device that does not enforce a :term:`secure boot` policy. For example, this can enable code reuse by using a single API for firmware update across devices that have different security requirements and policies. Although permitted by the |API|, this usage is not a focus for this specification.

--- a/doc/fwu/overview/goals.rst
+++ b/doc/fwu/overview/goals.rst
@@ -31,7 +31,7 @@ For example, the following resource constraints can affect the |API|:
    *  -  Delivery bandwidth
       -  Firmware download can take an extended period of time. The device might restart during this process.
    *  -  Energy and power
-      -  Downloading and installing updates must be reliable to wasting energy on failed or repeated update attempts.
+      -  Downloading and installing updates must be reliable to avoid wasting energy on failed or repeated update attempts.
    *  -  Performance of cryptographic primitives
       -  The use of cryptographic protection for firmware updates must match the security requirements for the device.
 

--- a/doc/fwu/overview/goals.rst
+++ b/doc/fwu/overview/goals.rst
@@ -44,7 +44,7 @@ The |API| is suitable for updating the device's :term:`Platform Root of Trust` (
 
 The :cite-title:`PSM` requires all of the :term:`Updatable Platform Root of Trust` firmware to be updatable. This can include bootloaders, Secure Partition Manager, Trusted OS, and runtime services. In some implementations, the PRoT can include a trusted subsystem with its own isolated and updatable firmware.
 
-The :cite:`PSM` requirements for firmware update are also reflected in certifications like :cite-title:`IR8259`, :cite-title:`EN303645`, and :cite-title:`PSA-CERT`. `[PSA-CERT]` provides the following definition of the F.FIRMWARE_UPDATE security function, where the Target of Evaluation (TOE) refers to the PRoT:
+The :cite:`PSM` requirements for firmware update are also reflected in publications such as :cite-title:`IR8259` and :cite-title:`EN303645`, and in certification schemes such as :cite-title:`PSA-CERT`. `[PSA-CERT]` provides the following definition of the F.FIRMWARE_UPDATE security function, where the Target of Evaluation (TOE) refers to the PRoT:
 
    The TOE verifies the integrity and authenticity of the TOE update prior to performing the update.
 

--- a/doc/fwu/overview/programming-model.rst
+++ b/doc/fwu/overview/programming-model.rst
@@ -272,13 +272,13 @@ The manifest must conform to a format that is expected by the implementation. It
 
 The manifest describes the type of device, and component, that the firmware is for. The implementation must check that this information matches the device and component being updated.
 
-The manifest provides the version of the new firmware image. The implementation must only install a later version of firmware than is currently installed.
+The manifest provides the version, or sequence number, of the new firmware image. For some deployments, the implementation must not install an earlier version of firmware than is currently installed. This security requirement prevents a firmware downgrade that can expose a known security vulnerability.
 
 The manifest can provide information about dependencies on other firmware images. The implementation must only install the new firmware if its dependencies are satisfied. See :secref:`dependencies`.
 
 .. admonition:: Implementation note
 
-   In a trusted-client implementation of the |API|, these steps can be carried out by the update client, and no verification is done by the implementation. See :secref:`trusted-client`.
+   In a trusted-client implementation of the |API|, these steps can be carried out by the update client, and then no verification is done by the implementation. See :secref:`trusted-client`.
 
 Firmware image verification
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -289,6 +289,9 @@ In a system that implements :term:`secure boot`, the firmware verification proce
 
 The implementation is permitted to defer all of the verification of the manifest and firmware image to the bootloader. However, it is recommended that as much verification as possible is carried out before rebooting the system. This reduces the loss of system availability during a reboot, or the cost of storing the firmware image, when it can be determined ahead of time that the update will fail at least one verification check. This recommendation is also made for systems which repeat the verification in the bootloader, prior to final installation and execution of the new firmware.
 
+.. admonition:: Implementation note
+
+   In a trusted-client implementation of the |API|, this verification can be carried out by the update client, and then no verification is done by the implementation. See :secref:`trusted-client`.
 
 .. _dependencies:
 
@@ -299,7 +302,11 @@ A firmware image can have a dependency on another component's firmware image. Wh
 
 A dependency can be satisfied by a firmware image that is already installed, or by a firmware image that is installed at the same time as the dependent image. In the latter case, both images must be prepared as candiate images before the ``install`` operation. If new firmware images for multiple components are inter-dependent, then the components must be installed at the same time. The :secref:`multi-component-example` example shows how this can be done.
 
-Dependencies are described in the firmware image manifest. It is the responsibility of the update client to update components in an order that ensures that dependencies are met during the installation process. Typically, the firmware creator and update server ensure that firmware image updates are presented to the update client in an appropriate order. In more advanced systems, a manifest might provide the update client with sufficient information to determine dependencies and installation order of multiple components itself.
+Dependencies are typically described in the firmware image manifest. It is the responsibility of the update client to update components in an order that ensures that dependencies are met during the installation process. Typically, the firmware creator and update server ensure that firmware image updates are presented to the update client in an appropriate order. In more advanced systems, a manifest might provide the update client with sufficient information to determine dependencies and installation order of multiple components itself.
+
+.. admonition:: Implementation note
+
+   In a trusted-client implementation of the |API|, dependency verification can be carried out by the update client, and then no verification is done by the implementation. See :secref:`trusted-client`.
 
 
 Update client operation

--- a/doc/fwu/overview/programming-model.rst
+++ b/doc/fwu/overview/programming-model.rst
@@ -54,7 +54,7 @@ The complete state model is applicable for components that have the following pr
 2. The image must be tested prior to acceptance.
 3. A candidate image is persistent across a reboot, before it is staged for installation.
 
-For components that do not require testing of new firmware before acceptance, or components that do not require a reboot to complete installation, only a subset of the states are visible to the update client. For components that do not retain a candidate image following a reboot, most component states will transition when the system restarts. Some common examples of alternative component update characteristics are described in :secref:`variations`, including the changes in the state model for such components.
+For components that do not require testing of new firmware before acceptance, or components that do not require a reboot to complete installation, only a subset of the states are visible to the update client. For components with :term:`volatile staging`, almost all component states will transition when the system restarts. Some common examples of alternative component update characteristics are described in :secref:`variations`, including the changes in the state model for such components.
 
 .. _component-state:
 
@@ -82,7 +82,7 @@ Component state
 
          When writing is complete, the image becomes a CANDIDATE for installation.
 
-         This state is always volatile for components that have volatile staging. For other components, it is :scterm:`implementation defined` whether this state is volatile.
+         This state is always volatile for components that have :term:`volatile staging`. For other components, it is :scterm:`implementation defined` whether this state is volatile.
 
          When this state is volatile, the incomplete image is discarded at reboot.
 
@@ -139,12 +139,12 @@ Volatile states
 
 A component state is 'volatile', if the state is not preserved when the system reboots.
 
-Volatile states are not optional for an implementation of the |API|. Until a device reboots, the update service must follow the state transitions and report the resulting states as shown in the state model appropriate for the component update characteristics.
+States that are volatile are not optional for an implementation of the |API|. Until a device reboots, the update service must follow the state transitions and report the resulting states as shown in the state model appropriate for the component update characteristics.
 
 *  READY state is never volatile.
 *  STAGED, TRIAL, and REJECTED states are always volatile.
-*  If the component sets the component flag `PSA_FWU_FLAG_VOLATILE_STAGING`, then CANDIDATE, WRITING, FAILED, and UPDATED states are volatile.
-*  If the component does not set component flag `PSA_FWU_FLAG_VOLATILE_STAGING`, then CANDIDATE state is non-volatile, and it is :scterm:`implementation defined` whether WRITING, FAILED, or UPDATED states are volatile.
+*  If the component has :term:`volatile staging`, then CANDIDATE, WRITING, FAILED, and UPDATED states are volatile.
+*  If the component does not have volatile staging, then CANDIDATE state is non-volatile, and it is :scterm:`implementation defined` whether WRITING, FAILED, or UPDATED states are volatile.
 
 In most cases, at reboot the implementation effectively implements one or more transitions to a final, non-volatile state. The exception is for a component that is STAGED, and enters TRIAL state following a successful installation at reboot.
 

--- a/doc/fwu/overview/programming-model.rst
+++ b/doc/fwu/overview/programming-model.rst
@@ -15,7 +15,7 @@ For each component, depending on the state or progress of a firmware update, the
 
 *  An *active* image that is actively in use by the system.
 *  A *staged* image that is being prepared for installation.
-*  A *backup* of a previously installed image, used to recover if an attempted update fails.
+*  A *backup* of the previous image that is being replaced, used to recover if an attempted update fails.
 *  A *dirty* image that can be erased.
 
 For a component that is essential for system operation, there will always be exactly one *active* image. Other images might, or might not, be present in the firmware store.
@@ -52,9 +52,9 @@ The complete state model is applicable for components that have the following pr
 
 1. A reboot is required to complete installation of a new image.
 2. The image must be tested prior to acceptance.
-3. A prepared image is persistent across a reboot, before it is staged for installation.
+3. A candidate image is persistent across a reboot, before it is staged for installation.
 
-For components that do not require testing of new firmware before acceptance, or components that do not require a reboot to complete installation, only a subset of the states are visible to the update client. For components that do not retain a prepared update following a reboot, almost all component states are volatile that will always transition when the system restarts. Some common examples of alternative component update characteristics are described in :secref:`variations`, including the changes in the state model for such components.
+For components that do not require testing of new firmware before acceptance, or components that do not require a reboot to complete installation, only a subset of the states are visible to the update client. For components that do not retain a candidate image following a reboot, most component states will transition when the system restarts. Some common examples of alternative component update characteristics are described in :secref:`variations`, including the changes in the state model for such components.
 
 .. _component-state:
 
@@ -78,30 +78,30 @@ Component state
          The component is ready for a new firmware update to be started.
 
    *  -  WRITING
-      -  The update client is writing a new firmware image to the staging area, in preparation for installation.
+      -  A new firmware image is being written to the staging area, in preparation for installation.
 
-         When writing is complete, it can be prepared for installation.
+         When writing is complete, the image becomes a CANDIDATE for installation.
 
          This state is always volatile for components that have volatile staging. For other components, it is :scterm:`implementation defined` whether this state is volatile.
 
          When this state is volatile, the incomplete image is discarded at reboot.
 
    *  -  CANDIDATE
-      -  The update client has completed transfer of the new firmware image to the staging area.
+      -  Transfer of the new firmware image to the staging area is complete.
 
-         When all components for update are prepared, they can be installed.
+         When all components that require update are in CANDIDATE state, they can be installed.
 
          This state is always volatile for components that have volatile staging. For other components, it is always persistent.
 
-         When this state is volatile, the prepared image is discarded at reboot.
+         When this state is volatile, the candidate image is discarded at reboot.
 
    *  -  STAGED
-      -  Installation of the prepared image has been requested, but the system must be restarted as the final update operation runs within the bootloader.
+      -  Installation of the candidate image has been requested, but the system must be restarted as the final update operation runs within the bootloader.
 
          This state is always volatile.
 
    *  -  TRIAL
-      -  Installation of the staged image has succeeded, and is now the *active* image running in 'trial mode'. This state is always volatile, and requires the update client to explicitly accept the trial to make the update permanent.
+      -  Installation of the staged image has succeeded, and is now the *active* image running in 'trial mode'. This state is always volatile, and requires the trial to be explicitly accepted to make the update permanent.
 
          In this state, the previously installed *active* image is preserved as the *second* image. If the trial is explicitly rejected, or the system restarts without accepting the trial, the previously installed image is re-installed and the trial image is rejected.
 
@@ -166,9 +166,9 @@ Table :numref:`tab-operations` shows the operations that the update client uses 
 
    ``start``, Begin a firmware update operation
    ``write``, "Write all, or part, of a firmware image"
-   ``finish``, Complete preparation of a firmware image
+   ``finish``, Complete preparation of a candidate firmware image
    ``cancel``, Abandon a firmware image that is being prepared
-   ``install``, Start the installation of new firmware images
+   ``install``, Start the installation of candidate firmware images
    ``accept``, Accept an installation that is being trialed
    ``reject``, Abandon an installation
    ``clean``, Erase firmware storage before starting a new update
@@ -297,7 +297,7 @@ Dependencies
 
 A firmware image can have a dependency on another component's firmware image. When a firmware image has a dependency it cannot be installed until all of its dependencies are satisfied.
 
-A dependency can be satisfied by a firmware image that is already installed, or by a firmware image that is installed at the same time as the dependent image. In the latter case, both images must be prepared, and in CANDIDATE state, before the ``install`` operation. If new firmware images for multiple components are inter-dependent, then the components must be installed at the same time. The :secref:`multi-component-example` example shows how this can be done.
+A dependency can be satisfied by a firmware image that is already installed, or by a firmware image that is installed at the same time as the dependent image. In the latter case, both images must be prepared as candiate images before the ``install`` operation. If new firmware images for multiple components are inter-dependent, then the components must be installed at the same time. The :secref:`multi-component-example` example shows how this can be done.
 
 Dependencies are described in the firmware image manifest. It is the responsibility of the update client to update components in an order that ensures that dependencies are met during the installation process. Typically, the firmware creator and update server ensure that firmware image updates are presented to the update client in an appropriate order. In more advanced systems, a manifest might provide the update client with sufficient information to determine dependencies and installation order of multiple components itself.
 
@@ -341,7 +341,7 @@ To prepare a new firmware image for a component, the update client calls `psa_fw
 
 The update client can now transfer the firmware image data to the firmware store by calling `psa_fwu_write()` one or more times. In systems with sufficient resources, the firmware image can be transferred in a single call. In systems with limited RAM, the update client can transfer the image incrementally, and specify the location of the provided data within the overall firmware image.
 
-When all of the firmware image has been transferred to the update service, the update client calls `psa_fwu_finish()` to complete the preparation of the firmware image. The implementation can verify the manifest and verify the image at this point, or can defer this until later in the process.
+When all of the firmware image has been transferred to the update service, the update client calls `psa_fwu_finish()` to complete the preparation of the candidate firmware image. The implementation can verify the manifest and verify the image at this point, or can defer this until later in the process.
 
 If preparation is successful, the component is now in CANDIDATE state.
 
@@ -354,12 +354,12 @@ Multi-component updates
 
 A system with multiple components might sometimes require that more than one component is updated atomically.
 
-To update multiple components atomically, all of the new firmware images must be prepared before proceeding to the installation step.
+To update multiple components atomically, all of the new firmware images must be prepared as candidates before proceeding to the installation step.
 
-Installing the new firmware image
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Installing the candidate firmware image
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Once the images have been prepared, the update client calls `psa_fwu_install()` to begin the installation process. This operation will apply to all components in CANDIDATE state. The implementation will complete the verification of the manifest data at this point, and can also verify the new firmware image.
+Once the images have been prepared as candidates, the update client calls `psa_fwu_install()` to begin the installation process. This operation will apply to all components in CANDIDATE state. The implementation will complete the verification of the manifest data at this point, and can also verify the new firmware image.
 
 Invoking the new firmware image can require part, or all, of the system to be restarted. If this is required, the affected components will be in STAGED state, and the call to `psa_fwu_install()` returns a status code that informs the update client of the action required.
 

--- a/doc/fwu/overview/programming-model.rst
+++ b/doc/fwu/overview/programming-model.rst
@@ -255,7 +255,7 @@ Verifying an update
 
 A firmware update is essentially authorized remote code execution. Any security weaknesses in the update process expose that remote code execution system. Failure to secure the firmware update process will help attackers take control of devices.
 
-It is not sufficient to rely on a :term:`secure boot` process to prevent execution of unauthorized firmware. This situation can easily result in an unusable device, as the installed firmware cannot be run, and the device can no longer update itself.
+Where the installation results in the loss of the previous image, verification of the image during a :term:`secure boot` process is not sufficient. If the boot time verification fails, then it is possible that the device can no longer operate, unless additional recovery mechanisms are implemented.
 
 It is important for the update process to verify that an update is appropriate for the device, authentic, correctly authorized, and not expected to result in a non-functioning system. This is achieved by verifying various aspects of the firmware and its manifest. The various checks can take place at different points in the update process, depending on the firmware update implementation architecture --- as a result, a verification failure can cause an error response in different function calls depending on the implementation.
 

--- a/doc/fwu/terms
+++ b/doc/fwu/terms
@@ -77,3 +77,17 @@
    Firmware image metadata that is signed with a cryptographic key. The manifest can be bundled within the firmware image, or detached from it.
 
    See :secref:`manifest`.
+
+.. term:: Volatile staging
+
+   A component with volatile staging does not preserve a firmware image that is in the :term:`staging area` after a reboot.
+
+   A component without volatile staging preserves a prepared candidate firmware image after a reboot. It is :scterm:`implementation defined` whether a partially prepared image in in the staging area is retained after a system reset.
+
+   See `PSA_FWU_FLAG_VOLATILE_STAGING`.
+
+.. term:: Staging area
+
+   A region within the firmware store used for a firmware image that is being transferred to the device. Once transfer is complete, the image in the staging area can be verified during installation.
+
+   See :secref:`arch-firmware-store`.

--- a/headers/fwu/1.0/psa/update.h
+++ b/headers/fwu/1.0/psa/update.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2020-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-FileCopyrightText: Copyright 2020-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
 // SPDX-License-Identifier: Apache-2.0
 
 /* This file is a reference template for implementation of the
@@ -121,8 +121,8 @@ typedef struct psa_fwu_image_version_t {
 #define PSA_FWU_UPDATED 7u
 
 /**
- * @brief Flag to indicate whether the image data in the component staging area
- *        is discarded at system reset.
+ * @brief Flag to indicate whether a candidate image in the component staging
+ *        area is discarded at system reset.
  */
 #define PSA_FWU_FLAG_VOLATILE_STAGING 0x00000001u
 
@@ -162,10 +162,10 @@ typedef struct psa_fwu_component_info_t {
 /**
  * @brief Retrieve the firmware store information for a specific firmware
  *        component.
- * 
+ *
  * @param component Firmware component for which information is requested.
  * @param info      Output parameter for component information.
- * 
+ *
  * @return Result status.
  */
 psa_status_t psa_fwu_query(psa_fwu_component_t component,
@@ -173,17 +173,23 @@ psa_status_t psa_fwu_query(psa_fwu_component_t component,
 
 /**
  * @brief Begin a firmware update operation for a specific firmware component.
- * 
+ *
  * @param component     Identifier of the firmware component to be updated.
  * @param manifest      A pointer to a buffer containing a detached manifest for
  *                      the update.
  * @param manifest_size The size of the detached manifest.
- * 
+ *
  * @return Result status.
  */
 psa_status_t psa_fwu_start(psa_fwu_component_t component,
                            const void *manifest,
                            size_t manifest_size);
+
+/**
+ * @brief Base-2 logarithm of the required alignment of firmware image data
+ *        blocks when calling psa_fwu_write().
+ */
+#define PSA_FWU_LOG2_WRITE_ALIGN /* implementation-defined value */
 
 /**
  * @brief The maximum permitted size for block in psa_fwu_write(), in bytes.
@@ -193,12 +199,12 @@ psa_status_t psa_fwu_start(psa_fwu_component_t component,
 /**
  * @brief Write a firmware image, or part of a firmware image, to its staging
  *        area.
- * 
+ *
  * @param component    Identifier of the firmware component being updated.
  * @param image_offset The offset of the data block in the whole image.
  * @param block        A buffer containing a block of image data.
  * @param block_size   Size of block, in bytes.
- * 
+ *
  * @return Result status.
  */
 psa_status_t psa_fwu_write(psa_fwu_component_t component,
@@ -208,58 +214,57 @@ psa_status_t psa_fwu_write(psa_fwu_component_t component,
 
 /**
  * @brief Mark a firmware image in the staging area as ready for installation.
- * 
+ *
  * @param component Identifier of the firmware component to install.
- * 
+ *
  * @return Result status.
  */
 psa_status_t psa_fwu_finish(psa_fwu_component_t component);
 
 /**
  * @brief Abandon an update that is in WRITING or CANDIDATE state.
- * 
+ *
  * @param component Identifier of the firmware component to be cancelled.
- * 
+ *
  * @return Result status.
  */
 psa_status_t psa_fwu_cancel(psa_fwu_component_t component);
 
 /**
  * @brief Prepare the component for another update.
- * 
+ *
  * @param component Identifier of the firmware component to tidy up.
- * 
+ *
  * @return Result status.
  */
 psa_status_t psa_fwu_clean(psa_fwu_component_t component);
 
 /**
- * @brief Start the installation of all firmware images that have been prepared
- *        for update.
- * 
+ * @brief Start the installation of all candidate firmware images.
+ *
  * @return Result status.
  */
 psa_status_t psa_fwu_install(void);
 
 /**
  * @brief Requests the platform to reboot.
- * 
+ *
  * @return Result status.
  */
 psa_status_t psa_fwu_request_reboot(void);
 
 /**
  * @brief Abandon an installation that is in STAGED or TRIAL state.
- * 
+ *
  * @param error An application-specific error code chosen by the application.
- * 
+ *
  * @return Result status.
  */
 psa_status_t psa_fwu_reject(psa_status_t error);
 
 /**
  * @brief Accept a firmware update that is currently in TRIAL state.
- * 
+ *
  * @return Result status.
  */
 psa_status_t psa_fwu_accept(void);


### PR DESCRIPTION
Some additional clarifications following final review:

* Improved the definition and references to 'volatile staging'
* Consistently use 'non-volatile' state/staging instead of 'persistent' state/staging
* Described the state volatility, and implications in the API definition, not just the programming model
* Consistently refer to a 'candidate image' rather than a mixture of 'candidate image', 'image in CANDIDATE state' and 'prepared image'
* Clarifications about the verification responsibilities of components