### PR TITLE
PSA_ERROR_INVALID_HANDLE: clarify that it's about existing objects

### DIFF
--- a/doc/crypto/api/library/status.rst
+++ b/doc/crypto/api/library/status.rst
@@ -56,7 +56,7 @@ Some of the common status codes have a more precise meaning when returned by a f
       - Meaning in the |API|
 
     * - :code:`PSA_ERROR_INVALID_HANDLE`
-      - A key identifier is not valid. See also :secref:`key-ids`.
+      - A key identifier does not refer to an existing key. See also :secref:`key-ids`.
 
     * - :code:`PSA_ERROR_BAD_STATE`
       - Multi-part operations return this error when one of the functions is called out of sequence. Refer to the function descriptions for permitted sequencing of functions.

--- a/doc/status-code/api/status-codes.rst
+++ b/doc/status-code/api/status-codes.rst
@@ -205,7 +205,9 @@ Error codes
 
    .. summary:: A status code that indicates that a handle parameter is not valid.
 
-   A function can return this error any time a handle parameter is invalid.
+   A function can return this error any time it expects a parameter to be a handle to an existing object, but the handle is invalid.
+
+   This status code is not intended for cases where the parameter is a value that is chosen by the caller, but the value does not satisfy a validity condition for handles of this kind. In such cases, it is recommended that a function returns `PSA_ERROR_ALREADY_EXISTS` if value is valid but already in use, and `PSA_ERROR_INVALID_ARGUMENT` or a more specific status code if the value is otherwise invalid.
 
 
 .. macro:: PSA_ERROR_BAD_STATE

--- a/doc/status-code/api/status-codes.rst
+++ b/doc/status-code/api/status-codes.rst
@@ -205,7 +205,7 @@ Error codes
 
    .. summary:: A status code that indicates that a handle parameter is not valid.
 
-   A function can return this error any time it expects a parameter to be a handle to an existing object, but the handle is invalid.
+   A function can return this error any time it expects a parameter to be a handle to an existing resource, but the handle is invalid.
 
    This status code is not intended for cases where the parameter is a value that is chosen by the caller, but the value does not satisfy a validity condition for handles of this kind. In such cases, it is recommended that a function returns `PSA_ERROR_ALREADY_EXISTS` if value is valid but already in use, and `PSA_ERROR_INVALID_ARGUMENT` or a more specific status code if the value is otherwise invalid.
 

--- a/doc/status-code/api/status-codes.rst
+++ b/doc/status-code/api/status-codes.rst
@@ -207,7 +207,7 @@ Error codes
 
    A function can return this error any time it expects a parameter to be a handle to an existing resource, but the handle is invalid.
 
-   This status code is not intended for cases where the parameter is a value that is chosen by the caller, but the value does not satisfy a validity condition for handles of this kind. In such cases, it is recommended that a function returns `PSA_ERROR_ALREADY_EXISTS` if value is valid but already in use, and `PSA_ERROR_INVALID_ARGUMENT` or a more specific status code if the value is otherwise invalid.
+   This status code is not recommended when a caller is requesting a specific handle value to be used for a new handle. In such cases, it is recommended that a function returns `PSA_ERROR_ALREADY_EXISTS` if value is valid but already in use, and `PSA_ERROR_INVALID_ARGUMENT` or a more specific status code if the value is otherwise invalid.
 
 
 .. macro:: PSA_ERROR_BAD_STATE


### PR DESCRIPTION
The current wording makes it look like the error also applies when creating an object with a caller-chosen handle and the caller's choice is not acceptable. See https://lists.trustedfirmware.org/archives/list/mbed-tls@lists.trustedfirmware.org/thread/DOBLFTSJMN2BGW3E7J6HVX6CXZ4YBKK3/