### PR TITLE
Clarify the required behavior of concurrent calls

### DIFF
--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -187,6 +187,8 @@ Clarifications and fixes
 
 *   Relax the requirement to use the defined key derivation methods in `psa_key_derivation_output_key()`: implementation-specific KDF algorithms can use implementation-defined methods to derive the key material.
 
+*   Clarify the requirements for implementations that support concurrent execution of API calls.
+
 Other changes
 ~~~~~~~~~~~~~
 

--- a/doc/crypto/overview/conventions.rst
+++ b/doc/crypto/overview/conventions.rst
@@ -393,7 +393,7 @@ calls to the API whose execution can overlap in time.
 
     The consistency requirement does not apply to errors that arise
     from resource failures or limitations. For example, errors resulting from
-    resource constraints can arise in concurrent execution that do not arise in
+    resource exhaustion can arise in concurrent execution that do not arise in
     sequential execution.
 
     As an example of this rule: suppose two calls are executed concurrently

--- a/doc/crypto/overview/conventions.rst
+++ b/doc/crypto/overview/conventions.rst
@@ -370,37 +370,45 @@ In some environments, an application can make calls to the |API| in
 separate threads. In such an environment, *concurrent calls* are two or more
 calls to the API whose execution can overlap in time.
 
-The result of two or more concurrent calls must be consistent with the same set
-of calls being executed sequentially in some order, provided that they obey the
-following constraints:
+**Sequential consistency**
+    The result of two or more concurrent calls must be consistent with the
+    same set of calls being executed sequentially in some order, provided that
+    the calls obey the following constraints:
 
-*   There is no overlap between an output parameter of one call and an input or
-    output parameter of another call. Overlap between input parameters is
-    permitted.
+    *   There is no overlap between an output parameter of one call and an
+        input or output parameter of another call. Overlap between input
+        parameters is permitted.
 
-*   A call to destroy a key must not overlap with a concurrent call to any of
-    the following functions:
+    *   A call to :code:`psa_destroy_key()` must not overlap with a concurrent
+        call to any of the following functions:
 
-    *   Any call where the same key identifier is a parameter to the call.
-    *   Any call in a multi-part operation, where the same key identifier was
-        used as a parameter to a previous step in the multi-part operation.
+        -   Any call where the same key identifier is a parameter to the call.
+        -   Any call in a multi-part operation, where the same key identifier
+            was used as a parameter to a previous step in the multi-part
+            operation.
 
-*   Concurrent calls must not use the same operation object.
+    *   Concurrent calls must not use the same operation object.
 
-If any of these constraints are violated, the behavior is undefined.
+    If any of these constraints are violated, the behavior is undefined.
 
-For example, suppose two calls are executed concurrently which both attempt to
-create a new key with the same key identifier that is not already in the key
-store. Then:
+    Note that this consistency requirement does not apply to errors that arise
+    from resource failures or limitations, for example, errors resulting from
+    resource constraints can arise in concurrent execution that do not arise in
+    sequential execution.
 
-*   If one call returns :code:`PSA_ERROR_ALREADY_EXISTS`, then the other call
-    must succeed.
-*   If one of the calls succeeds, then the other must fail: either with
-    :code:`PSA_ERROR_ALREADY_EXISTS` or some other error status.
-*   Both calls can fail with error codes that are not
-    :code:`PSA_ERROR_ALREADY_EXISTS`.
+    For example, suppose two calls are executed concurrently which both attempt
+    to create a new key with the same key identifier that is not already in the
+    key store. Then:
 
-If the application concurrently modifies an input parameter while a function
-call is in progress, the behavior is undefined.
+    *   If one call returns :code:`PSA_ERROR_ALREADY_EXISTS`, then the other
+        call must succeed.
+    *   If one of the calls succeeds, then the other must fail: either with
+        :code:`PSA_ERROR_ALREADY_EXISTS` or some other error status.
+    *   Both calls can fail with error codes that are not
+        :code:`PSA_ERROR_ALREADY_EXISTS`.
+
+**Parameter stability**
+    If the application concurrently modifies an input parameter while a
+    function call is in progress, the behavior is undefined.
 
 Individual implementations can provide additional guarantees.

--- a/doc/crypto/overview/conventions.rst
+++ b/doc/crypto/overview/conventions.rst
@@ -391,14 +391,14 @@ calls to the API whose execution can overlap in time.
 
     If any of these constraints are violated, the behavior is undefined.
 
-    Note that this consistency requirement does not apply to errors that arise
-    from resource failures or limitations, for example, errors resulting from
+    The consistency requirement does not apply to errors that arise
+    from resource failures or limitations. For example, errors resulting from
     resource constraints can arise in concurrent execution that do not arise in
     sequential execution.
 
-    For example, suppose two calls are executed concurrently which both attempt
-    to create a new key with the same key identifier that is not already in the
-    key store. Then:
+    As an example of this rule: suppose two calls are executed concurrently
+    which both attempt to create a new key with the same key identifier that is
+    not already in the key store. Then:
 
     *   If one call returns :code:`PSA_ERROR_ALREADY_EXISTS`, then the other
         call must succeed.

--- a/doc/crypto/overview/conventions.rst
+++ b/doc/crypto/overview/conventions.rst
@@ -370,8 +370,9 @@ In some environments, an application can make calls to the |API| in
 separate threads. In such an environment, *concurrent calls* are two or more
 calls to the API whose execution can overlap in time.
 
-Concurrent calls are performed correctly, as if the calls were executed in
-sequence, provided that they obey the following constraints:
+The result of two or more concurrent calls must be consistent with the same set
+of calls being executed sequentially in some order, provided that they obey the
+following constraints:
 
 *   There is no overlap between an output parameter of one call and an input or
     output parameter of another call. Overlap between input parameters is
@@ -388,7 +389,18 @@ sequence, provided that they obey the following constraints:
 
 If any of these constraints are violated, the behavior is undefined.
 
-If the application modifies an input parameter while a function call is in
-progress, the behavior is undefined.
+For example, suppose two calls are executed concurrently which both attempt to
+create a new key with the same key identifier that is not already in the key
+store. Then:
+
+*   If one call returns :code:`PSA_ERROR_ALREADY_EXISTS`, then the other call
+    must succeed.
+*   If one of the calls succeeds, then the other must fail: either with
+    :code:`PSA_ERROR_ALREADY_EXISTS` or some other error status.
+*   Both calls can fail with error codes that are not
+    :code:`PSA_ERROR_ALREADY_EXISTS`.
+
+If the application concurrently modifies an input parameter while a function
+call is in progress, the behavior is undefined.
 
 Individual implementations can provide additional guarantees.


### PR DESCRIPTION
Relax/clarify the statement regarding the required behavior of implementations that support concurrent execution of calls to the API.

Fixes #134