### PR TITLE
Correct the document date for Crypto 1.1.2

### DIFF
--- a/doc/crypto/conf.py
+++ b/doc/crypto/conf.py
@@ -43,7 +43,7 @@ doc_info = {
     'license': 'psa-certified-api-license',
 
     # Document date, default to build date
-    'date': '23/03/2022',
+    'date': '23/03/2023',
 
     # Default header file for API definitions
     # default to None, and can be set in documentation source


### PR DESCRIPTION
Create a new branch for this minor fix, based on the crypto-1.1.2 tag. See #130.