### PR TITLE
Change of PAKE extension status to REL/Final

### DIFF
--- a/doc/ext-pake/about.rst
+++ b/doc/ext-pake/about.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2022, 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. include:: releases
@@ -13,12 +13,18 @@
     The detailed changes in each release are described in :secref:`changes`.
 
 .. potential-for-change::
-    :hide:
+
+    The contents of this specification are stable for version |docversion|.
+
+    The following may change in updates to the version |docversion| specification:
+
+    *   Small optional feature additions.
+    *   Clarifications.
+
+    Significant additions, or any changes that affect the compatibility of the interfaces defined in this specification will only be included in a new major or minor version of the specification.
 
 .. current-status::
 
-    This document is at Beta quality status which has a particular meaning to Arm of which the recipient must be aware.
-    A Beta quality specification will be sufficiently stable & committed for initial product development, however all aspects of the architecture described herein remain SUBJECT TO CHANGE.
-    Please ensure that you have the latest revision.
+    This document is at Release/Final quality status.
 
 .. about::

--- a/doc/ext-pake/api/encodings.rst
+++ b/doc/ext-pake/api/encodings.rst
@@ -6,12 +6,11 @@
 Algorithm and key type encoding
 ===============================
 
-These are encodings for a proposed PAKE interface for :cite-title:`PSA-CRYPT`.
-It is not part of the official |API| yet.
+These are encodings for a PAKE interface for :cite-title:`PSA-CRYPT`.
 
 .. note::
 
-    The content of this specification is not part of the stable |API| and may change substantially from version to version.
+    These encodings will be integrated into a future version of :cite:`PSA-CRYPT`.
 
 Algorithm encoding
 ------------------

--- a/doc/ext-pake/api/pake.rst
+++ b/doc/ext-pake/api/pake.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2022-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 Password-authenticated key exchange (PAKE)
@@ -6,10 +6,7 @@ Password-authenticated key exchange (PAKE)
 
 .. note::
 
-    This is a proposed PAKE interface for :cite-title:`PSA-CRYPT`.
-    It is not part of the official |API| yet.
-
-    The content of this specification is not part of the stable |API| and may change substantially from version to version.
+    The API defined in this specification will be integrated into a future version of :cite:`PSA-CRYPT`.
 
 This chapter is divided into the following sections:
 
@@ -37,7 +34,7 @@ Common API for PAKE
     :license: Apache-2.0
 
     /* This file contains reference definitions for implementation of the
-     * PSA Certified Crypto API v1.2 PAKE Extension beta.2
+     * PSA Certified Crypto API v1.2 PAKE Extension
      *
      * These definitions must be embedded in, or included by, psa/crypto.h
      */

--- a/doc/ext-pake/appendix/history.rst
+++ b/doc/ext-pake/appendix/history.rst
@@ -11,7 +11,7 @@ Document change history
 
 This section provides the detailed changes made between published version of the document.
 
-Changes between *Beta 1* and *Beta 2*
+Changes between *Beta 1* and *Final*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 API changes

--- a/doc/ext-pake/conf.py
+++ b/doc/ext-pake/conf.py
@@ -26,13 +26,13 @@ doc_info = {
     'extension_doc': 'PAKE Extension',
 
     # Arm document quality status, marked as open issue if not provided
-    'quality': 'BET',
+    'quality': 'REL',
     # Arm document issue number (within that version and quality status)
     # Marked as open issue if not provided
-    'issue_no': 2,
+    'issue_no': 0,
     # Identifies the sequence number of a release candidate of the same issue
     # default to None
-    'release_candidate': 1,
+    'release_candidate': 2,
     # Draft status - use this to indicate the document is not ready for publication
     'draft': False,
 

--- a/doc/ext-pake/index.rst
+++ b/doc/ext-pake/index.rst
@@ -1,15 +1,13 @@
-.. SPDX-FileCopyrightText: Copyright 2022-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 ..  title::
 
-    .. banner:: BETA RELEASE
+    .. banner:: FINAL RELEASE
 
-        This is a proposed update to the :cite-title:`PSA-CRYPT` specification.
+        This is an extension to the :cite-title:`PSA-CRYPT` specification.
 
-        This is a BETA release in order to enable wider review and feedback on the changes proposed to be included in a future version of the specification.
-
-        At this quality level, the proposed changes and interfaces are complete, and suitable for initial product development. However, the specification is still subject to change.
+        This is a FINAL release: the proposed changes and interfaces are complete and finalized, and suitable for product development.
 
     .. abstract::
 

--- a/doc/ext-pake/overview/intro.rst
+++ b/doc/ext-pake/overview/intro.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2022-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 Introduction
@@ -14,13 +14,13 @@ About the |API| PAKE Extension
 
 This document defines an extension to the :cite-title:`PSA-CRYPT` specification, to provide support for :term:`Password-authenticated key exchange` (PAKE) protocols, and specifically for the J-PAKE and SPAKE2+ protocols.
 
-When the proposed extension API is sufficiently stable to be classed as Final, it will be integrated into a future version of `[PSA-CRYPT]`.
+This extension API is now classed as Final, and it will be integrated into a future version of `[PSA-CRYPT]`.
 
 This specification must be read and implemented in conjunction with `[PSA-CRYPT]`. All of the conventions, design considerations, and implementation considerations that are described in `[PSA-CRYPT]` apply to this specification.
 
 .. rationale:: Note
 
-    This version of the document includes *Rationale* commentary that provides background information relating to the design decisions that led to the current proposal. This enables the reader to understand the wider context and alternative approaches that have been considered.
+    This version of the document includes *Rationale* commentary that provides background information relating to the API design. This enables the reader to understand the wider context and alternative approaches that have been considered.
 
 
 Objectives for the PAKE Extension
@@ -42,7 +42,10 @@ Requests
 ^^^^^^^^
 
 Some PAKE schemes have been requested by the community and need to be supported.
-Currently, these are SPAKE2+ and J-PAKE (in particular the Elliptic Curve based variant, sometimes known as ECJPAKE)
+Currently, these are:
+
+*   SPAKE2+ --- used in :cite-title:`MATTER`
+*   J-PAKE (in particular the Elliptic Curve based variant, sometimes known as ECJPAKE) --- used in :cite-title:`THREAD`.
 
 Standardization
 ^^^^^^^^^^^^^^^
@@ -67,7 +70,7 @@ Some of these schemes are used in popular protocols. This information confirms t
     *   -   J-PAKE
         -   TLS, THREAD v1
     *   -   SPAKE2+
-        -   CHIP
+        -   MATTER
     *   -   SRP
         -   TLS
     *   -   OPAQUE

--- a/doc/ext-pake/references
+++ b/doc/ext-pake/references
@@ -41,3 +41,9 @@
     :author: IETF
     :publication: December 2020
     :url: datatracker.ietf.org/doc/draft-bar-cfrg-spake2plus-02
+
+.. reference:: THREAD
+    :title: Thread Specification 1.3.0
+    :author: Thread Group
+    :publication: July 2022
+    :url: www.threadgroup.org/ThreadSpec

--- a/doc/ext-pake/releases
+++ b/doc/ext-pake/releases
@@ -13,10 +13,12 @@
 
     Relicensed as open source under CC BY-SA 4.0.
 
-.. release:: Beta 2
-    :date: January 2024
+.. release:: Final
+    :date: February 2024
     :confidentiality: Non-confidential
 
     Add support for the SPAKE2+ protocol.
 
     Rework the API to support augmented PAKE protocols, improve ease of use and implementation.
+
+    API status is now Final/Release.


### PR DESCRIPTION
Following review of a proof-of-concept implementation of the Beta-2 API specification, I would like to change the status of the PAKE API to 'final'/'release'. This will make the PAKE API subject to the same change control as the main Crypto API specification.

* Update the configuration for 'Final' status (RC2)
* Update references to the status
* Update description of the API status throughout the document
* Update the introduction text relating to the adoption of J-PAKE and SPAKE2+

Fixes #93