### PR TITLE
Fix references in Crypto API to the updated PAKE API

### DIFF
--- a/doc/crypto/api/ops/kdf.rst
+++ b/doc/crypto/api/ops/kdf.rst
@@ -339,13 +339,13 @@ Key derivation algorithms
 
     *   `PSA_KEY_DERIVATION_INPUT_SECRET` is the shared secret :math:`K` from EC J-PAKE. For secp256r1, the input is exactly 65 bytes.
 
-        The input can be supplied to the key derivation operation by calling :code:`psa_pake_get_implicit_key()`, part of the PAKE extension API defined in :cite:`PSA-PAKE`.
+        The shared secret can be obtained by calling :code:`pake_get_shared_key()` on a PAKE operation that is performing the EC J-PAKE algorithm. These are defined in the PAKE extension API, see :cite:`PSA-PAKE`.
 
     The 32-byte output has to be read in a single call to either `psa_key_derivation_output_bytes()` or `psa_key_derivation_output_key()`. The size of the output is defined as `PSA_TLS12_ECJPAKE_TO_PMS_OUTPUT_SIZE`.
 
     .. subsection:: Compatible key types
 
-        None --- the secret input is extracted from a PAKE operation by calling :code:`psa_pake_get_implicit_key()`.
+        | `PSA_KEY_TYPE_DERIVE` --- the secret key is extracted from a PAKE operation by calling :code:`psa_pake_get_shared_key()`.
 
 .. macro:: PSA_ALG_PBKDF2_HMAC
     :definition: /* specification-defined value */

--- a/doc/crypto/api/ops/kdf.rst
+++ b/doc/crypto/api/ops/kdf.rst
@@ -339,7 +339,7 @@ Key derivation algorithms
 
     *   `PSA_KEY_DERIVATION_INPUT_SECRET` is the shared secret :math:`K` from EC J-PAKE. For secp256r1, the input is exactly 65 bytes.
 
-        The shared secret can be obtained by calling :code:`pake_get_shared_key()` on a PAKE operation that is performing the EC J-PAKE algorithm. These are defined in the PAKE extension API, see :cite:`PSA-PAKE`.
+        The shared secret can be obtained by calling :code:`psa_pake_get_shared_key()` on a PAKE operation that is performing the EC J-PAKE algorithm. These are defined in the PAKE extension API, see :cite:`PSA-PAKE`.
 
     The 32-byte output has to be read in a single call to either `psa_key_derivation_output_bytes()` or `psa_key_derivation_output_key()`. The size of the output is defined as `PSA_TLS12_ECJPAKE_TO_PMS_OUTPUT_SIZE`.
 

--- a/doc/crypto/overview/intro.rst
+++ b/doc/crypto/overview/intro.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2018-2022 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2018-2022, 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 Introduction
@@ -26,7 +26,7 @@ This document includes:
 *   General considerations for implementers of this specification, and for applications that use the interface defined in this specification. See :secref:`implementation-considerations` and :secref:`usage-considerations`.
 *   A detailed definition of the API. See :secref:`library-management`, :secref:`key-management`, and :secref:`crypto-operations`.
 
-:cite-title:`PSA-PAKE` is a companion document for version |docversion| of this specification. :cite:`PSA-PAKE` defines a new API for Password Authenticated Key Establishment (PAKE) algorithms. The PAKE API is an initial proposal at BETA status. The API defined by :cite:`PSA-PAKE` is provided in a separate specification to reflect the different status of this API, and indicate that a future version can include incompatible changes to the PAKE API. When the PAKE API is stable, it will be included in a future version of the |API| specification.
+:cite-title:`PSA-PAKE` is a companion document for version |docversion| of this specification. :cite:`PSA-PAKE` defines an API for Password Authenticated Key Establishment (PAKE) algorithms. The PAKE API is now at FINAL status, and the it will be included in a future version of the |API| specification.
 
 In future, other companion documents will define *profiles* for this specification. A profile is
 a minimum mandatory subset of the interface that a compliant implementation must

--- a/doc/crypto/references
+++ b/doc/crypto/references
@@ -1,8 +1,8 @@
-.. SPDX-FileCopyrightText: Copyright 2020-2023 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2020-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. reference:: PSA-PAKE
-    :title: PSA Certified Crypto API 1.1 PAKE Extension
+    :title: PSA Certified Crypto API 1.2 PAKE Extension
     :doc_no: ARM AES 0058
     :url: arm-software.github.io/psa-api/crypto
 


### PR DESCRIPTION
* Update ECJPAKE-TO-PMS KDF to reflect the new PAKE API
* Update references to the version and status of the PAKE API

Fixes #161
