### PR TITLE
Provide incremental by-subsystem initialization for the crypto library

### DIFF
--- a/doc/crypto/api.db/psa/crypto.h
+++ b/doc/crypto/api.db/psa/crypto.h
@@ -4,6 +4,7 @@
 typedef /* implementation-defined type */ psa_aead_operation_t;
 typedef uint32_t psa_algorithm_t;
 typedef /* implementation-defined type */ psa_cipher_operation_t;
+typedef uint32_t psa_crypto_subsystem_t;
 typedef uint8_t psa_dh_family_t;
 typedef uint8_t psa_ecc_family_t;
 typedef /* implementation-defined type */ psa_hash_operation_t;
@@ -204,8 +205,16 @@ typedef uint8_t psa_pake_step_t;
     /* implementation-defined value */
 #define PSA_CIPHER_UPDATE_OUTPUT_SIZE(key_type, alg, input_length) \
     /* implementation-defined value */
+#define PSA_CRYPTO_ALL_SUBSYSTEMS /* implementation-defined value */
 #define PSA_CRYPTO_API_VERSION_MAJOR 1
 #define PSA_CRYPTO_API_VERSION_MINOR 3
+#define PSA_CRYPTO_SUBSYSTEM_ACCELERATORS /* implementation-defined value */
+#define PSA_CRYPTO_SUBSYSTEM_BUILTIN_KEYS /* implementation-defined value */
+#define PSA_CRYPTO_SUBSYSTEM_COMMUNICATION /* implementation-defined value */
+#define PSA_CRYPTO_SUBSYSTEM_KEYS /* implementation-defined value */
+#define PSA_CRYPTO_SUBSYSTEM_RANDOM /* implementation-defined value */
+#define PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS /* implementation-defined value */
+#define PSA_CRYPTO_SUBSYSTEM_STORAGE /* implementation-defined value */
 #define PSA_DH_FAMILY_RFC7919 ((psa_dh_family_t) 0x03)
 #define PSA_ECC_FAMILY_BRAINPOOL_P_R1 ((psa_ecc_family_t) 0x30)
 #define PSA_ECC_FAMILY_FRP ((psa_ecc_family_t) 0x33)
@@ -494,6 +503,7 @@ psa_status_t psa_copy_key(psa_key_id_t source_key,
                           const psa_key_attributes_t * attributes,
                           psa_key_id_t * target_key);
 psa_status_t psa_crypto_init(void);
+psa_status_t psa_crypto_init_subsystem(psa_crypto_subsystem_t subsystem);
 psa_status_t psa_destroy_key(psa_key_id_t key);
 psa_status_t psa_export_key(psa_key_id_t key,
                             uint8_t * data,

--- a/doc/crypto/api/keys/attributes.rst
+++ b/doc/crypto/api/keys/attributes.rst
@@ -159,7 +159,7 @@ Managing key attributes
     .. retval:: PSA_ERROR_DATA_CORRUPT
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     This function first resets the attribute object as with `psa_reset_key_attributes()`. It then copies the attributes of the given key into the given attribute object.
 

--- a/doc/crypto/api/keys/management.rst
+++ b/doc/crypto/api/keys/management.rst
@@ -86,7 +86,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing, see :secref:`library-init`.
 
     This function supports any output from `psa_export_key()`. Each key type in :secref:`key-types` describes the expected format of keys.
 
@@ -149,7 +149,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
     .. retval:: PSA_ERROR_DATA_CORRUPT
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing, see :secref:`library-init`.
 
     The key is generated randomly. Its location, policy, type and size are taken from ``attributes``.
 
@@ -214,7 +214,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing, see :secref:`library-init`.
 
     Copy key material from one location to another.
 
@@ -267,7 +267,7 @@ Key destruction
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
         An unexpected condition which is not a storage corruption or a communication failure occurred. The cryptoprocessor might have been compromised.
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing, see :secref:`library-init`.
 
     This function destroys a key from both volatile memory and, if applicable, non-volatile storage. Implementations must make a best effort to ensure that that the key material cannot be recovered.
 
@@ -297,7 +297,7 @@ Key destruction
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing, see :secref:`library-init`.
 
     For keys that have been created with the `PSA_KEY_USAGE_CACHE` usage flag, an implementation is permitted to make additional copies of the key material that are not in storage and not for the purpose of ongoing operations.
 
@@ -362,7 +362,7 @@ Key export
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing, see :secref:`library-init`.
 
     The output of this function can be passed to `psa_import_key()` to create an equivalent object.
 
@@ -414,7 +414,7 @@ Key export
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing, see :secref:`library-init`.
 
     The output of this function can be passed to `psa_import_key()` to create an object that is equivalent to the public key.
 

--- a/doc/crypto/api/library/library.rst
+++ b/doc/crypto/api/library/library.rst
@@ -40,6 +40,37 @@ API version
 Library initialization
 ----------------------
 
+It is recommended that applications initialize the |API| implementation, before calling any other function, except as otherwise indicated.
+This is typically achieved by calling `psa_crypto_init()`.
+
+Some implementations provide the ability to selectively initialize a subset of the functionality, using calls to `psa_crypto_init_subsystem()`.
+For example, this permits use cases such as early-stage bootloaders, that need to decrypt or authenticate firmware, where it is unnecessary to wait for an RNG to collect enough entropy.
+In these implementations, calling `psa_crypto_init()` is equivalent to calling `psa_crypto_init_subsystem()` for all available subsystems.
+
+Applications are permitted to call these functions more than once.
+Once a subsystem is successfully initialized, subsequent calls to initialize the same subsystem are guaranteed to succeed.
+
+If the application calls any function that returns a :code:`psa_status_t` result code before initializing the related subsystems, the following will occur:
+
+*   If initialization of the library is essential for secure operation of the function, the implementation must return :code:`PSA_ERROR_BAD_STATE` or other appropriate error.
+
+*   If failure to initialize the library does not compromise the security of the function, the implementation must either provide the expected result for the function, or return :code:`PSA_ERROR_BAD_STATE` or other appropriate error.
+
+.. note::
+
+    The following scenarios are examples where an implementation can require that the library has been initialized:
+
+    *   A client-server implementation, in which `psa_crypto_init()`, or :code:`psa_crypto_init_subsystem(PSA_CRYPTO_SUBSYSTEM_COMMUNICATION)`, establishes the communication with the server.
+        No key management or cryptographic operation can be performed until this is done.
+
+    *   An implementation in which `psa_crypto_init()`, or :code:`psa_crypto_init_subsystem(PSA_CRYPTO_SUBSYSTEM_RANDOM)`, initializes the random bit generator, and no operations that require the RNG can be performed until this is done.
+        For example, random data, key, IV, or nonce generation; randomized signature or encryption; and algorithms that are implemented with blinding.
+
+.. warning::
+
+    The set of functions that depend on successful initialization of specific subsystems, is :scterm:`IMPLEMENTATION DEFINED`.
+    Applications that rely on calling functions before initializing the library might not be portable to other implementations.
+
 .. function:: psa_crypto_init
 
     .. summary::
@@ -52,24 +83,156 @@ Library initialization
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_INSUFFICIENT_ENTROPY
+    .. retval:: PSA_ERROR_INSUFFICIENT_STORAGE
+    .. retval:: PSA_ERROR_HARDWARE_FAILURE
+    .. retval:: PSA_ERROR_STORAGE_FAILURE
+    .. retval:: PSA_ERROR_DATA_INVALID
+    .. retval:: PSA_ERROR_DATA_CORRUPT
 
-    It is recommended that applications call this function before calling any other function in this module.
+    It is recommended that applications call this function before calling any other function in this module, except as otherwise indicated.
 
     Applications are permitted to call this function more than once. Once a call succeeds, subsequent calls are guaranteed to succeed.
 
-    If the application calls any function that returns a :code:`psa_status_t` result code before calling `psa_crypto_init()`, the following will occur:
+    For finer control over initialization, see `psa_crypto_init_subsystem()`.
 
-    *   If initialization of the library is essential for secure operation of the function, the implementation must return :code:`PSA_ERROR_BAD_STATE` or other appropriate error.
+    See also :secref:`library-init`.
 
-    *   If failure to initialize the library does not compromise the security of the function, the implementation must either provide the expected result for the function, or return :code:`PSA_ERROR_BAD_STATE` or other appropriate error.
+.. typedef:: uint32_t psa_crypto_subsystem_t
+
+    .. summary::
+        Encoding of a subsystem of the |API| implementation.
+
+    This type is used to specify implementation subsystems in a call to `psa_crypto_init_subsystem()`.
+    Values of this type are ``PSA_CRYPTO_SUBSYSTEM_xxx`` constants, or a bitwise-or of two or more of them.
+
+    .. admonition:: Implementation note
+
+        An implementation can define additional subsystem identifier values for use with `psa_crypto_init_subsystem()`.
+
+.. macro:: PSA_CRYPTO_SUBSYSTEM_COMMUNICATION
+    :definition: /* implementation-defined value */
+
+    .. summary::
+        Crypto subsystem identifier for the communication with the server, if this is a client that communicates with a server where the key store is located.
+
+    In a client-server implementation, initializing this subsystem is necessary before any API function other than library initialization, deinitialization and functions accessing local data structures such as key attributes.
+
+    In a library implementation, initializing this subsystem has no effect, and always succeeds.
+
+.. macro:: PSA_CRYPTO_SUBSYSTEM_KEYS
+    :definition: /* implementation-defined value */
+
+    .. summary::
+        Crypto subsystem identifier for the key store in memory.
+
+    Initializing this subsystem allows creating, accessing and destroying volatile keys in the default location, that is, keys with the lifetime `PSA_KEY_LIFETIME_VOLATILE`.
+
+    Persistent keys also require `PSA_CRYPTO_SUBSYSTEM_STORAGE`.
+    Keys in other locations also require `PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS`.
+
+
+.. macro:: PSA_CRYPTO_SUBSYSTEM_STORAGE
+    :definition: /* implementation-defined value */
+
+    .. summary::
+        Crypto subsystem identifier for access to keys in storage.
+
+    Initializing this subsystem and the `PSA_CRYPTO_SUBSYSTEM_KEYS` subsystem allows creating, accessing, and destroying persistent keys.
+
+    Persistent keys in secure elements also require `PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS`.
+
+.. macro:: PSA_CRYPTO_SUBSYSTEM_ACCELERATORS
+    :definition: /* implementation-defined value */
+
+    .. summary::
+        Crypto subsystem identifier for accelerator drivers.
+
+    Initializing this subsystem results in initialization of all registered accelerator drivers.
+
+    Initializing this subsystem allows cryptographic operations that are implemented via an accelerator driver.
+
+.. macro:: PSA_CRYPTO_SUBSYSTEM_SECURE_ELEMENTS
+    :definition: /* implementation-defined value */
+
+    .. summary::
+        Crypto subsystem identifier for secure element drivers.
+
+    Initializing this subsystem results in initialization of all registered secure element drivers.
+
+    Initializing this subsystem as well as `PSA_CRYPTO_SUBSYSTEM_KEYS` allows creating, accessing, and destroying keys in a secure element. That is, keys whose location is not `PSA_KEY_LOCATION_LOCAL_STORAGE`.
+
+.. macro:: PSA_CRYPTO_SUBSYSTEM_RANDOM
+    :definition: /* implementation-defined value */
+
+    .. summary::
+        Crypto subsystem identifier for the random generator.
+
+    Initializing this subsystem initializes all registered entropy drivers, and accesses the registered entropy sources.
+
+    Initializing this subsystem is necessary for `psa_generate_random()`, `psa_generate_key()`, and some operations using private or secret keys.
+
+    It is guaranteed that the following operations do not to require this subsystem:
+
+    *   Hash operations.
+    *   Signature verification operations.
+
+    Is it :scterm:`implementation defined` whether other operations require the initialization of this subsystem.
+
+.. macro:: PSA_CRYPTO_SUBSYSTEM_BUILTIN_KEYS
+    :definition: /* implementation-defined value */
+
+    .. summary::
+        Crypto subsystem identifier for access to built-in keys.
+
+    Initializing this subsystem as well as `PSA_CRYPTO_SUBSYSTEM_KEYS` allows access to built-in keys.
+
+.. macro:: PSA_CRYPTO_ALL_SUBSYSTEMS
+    :definition: /* implementation-defined value */
+
+    .. summary::
+        Crypto subsystem identifier for all available subsystems.
+
+    Using this value in a call to `psa_crypto_init_subsystem()` is equivalent to calling `psa_crypto_init()`.
+
+.. function:: psa_crypto_init_subsystem
+
+    .. summary::
+        Partial library initialization.
+
+    .. param:: psa_crypto_subsystem_t subsystem
+        The subsystem, or set of subsystems, to initialize.
+        This must be one of the ``PSA_CRYPTO_SUBSYSTEM_xxx`` values, one of the implementation-specific subsystem values, or a bitwise-or of them.
+
+    .. return:: psa_status_t
+    .. retval:: PSA_SUCCESS
+        Success.
+    .. retval:: PSA_ERROR_INVALID_ARGUMENT
+        ``subsystem`` is not a bitwise-or of one or more of the crypto subsystem identifier values.
+        These values can be defined in this specification or by the implementation.
+    .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
+    .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
+    .. retval:: PSA_ERROR_CORRUPTION_DETECTED
+    .. retval:: PSA_ERROR_INSUFFICIENT_ENTROPY
+    .. retval:: PSA_ERROR_INSUFFICIENT_STORAGE
+    .. retval:: PSA_ERROR_HARDWARE_FAILURE
+    .. retval:: PSA_ERROR_STORAGE_FAILURE
+    .. retval:: PSA_ERROR_DATA_INVALID
+    .. retval:: PSA_ERROR_DATA_CORRUPT
+
+    Applications may call this function on the same subsystem more than once.
+    Once a call succeeds, subsequent calls with the same subsystem are guaranteed to succeed.
+
+    Initializing a subsystem may initialize other subsystems if the implementations needs them internally.
+    For example, in a typical client-server implementation, `PSA_CRYPTO_SUBSYSTEM_COMMUNICATION` is required for all other subsystems, and therefore initializing any other subsystem also initializes `PSA_CRYPTO_SUBSYSTEM_COMMUNICATION`.
+
+    Calling `psa_crypto_init_subsystem()` with for a subsystem that is not used by the implementation must have no effect, and return :code:`PSA_SUCCESS`.
+    In effect, this is indicating that there is no further initialization required for this subsystem.
+
+    Calling `psa_crypto_init()` is equivalent to calling :code:`psa_crypto_init_subsystem(PSA_CRYPTO_ALL_SUBSYSTEMS)`.
+
+    See also :secref:`library-init`.
 
     .. note::
 
-        The following scenarios are examples where an implementation can require that the library has been initialized by calling `psa_crypto_init()`:
-
-        *   A client-server implementation, in which `psa_crypto_init()` establishes the communication with the server. No key management or cryptographic operation can be performed until this is done.
-
-        *   An implementation in which `psa_crypto_init()` initializes the random bit generator, and no operations that require the RNG can be performed until this is done. For example, random data, key, IV, or nonce generation; randomized signature or encryption; and algorithms that are implemented with blinding.
-
-    .. warning::
-        The set of functions that depend on successful initialization of the library is :scterm:`IMPLEMENTATION DEFINED`. Applications that rely on calling functions before initializing the library might not be portable to other implementations.
+        Multiple subsystems can be initialized in the same call by passing a bitwise-or of ``PSA_CRYPTO_SUBSYSTEM_xxx`` values.
+        If the initialization of one subsystem fails, it is unspecified whether other requested subsystems are initialized or not.

--- a/doc/crypto/api/ops/aead.rst
+++ b/doc/crypto/api/ops/aead.rst
@@ -285,7 +285,7 @@ Single-part AEAD functions
     .. retval:: PSA_ERROR_DATA_CORRUPT
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
 .. function:: psa_aead_decrypt
 
@@ -353,7 +353,7 @@ Single-part AEAD functions
     .. retval:: PSA_ERROR_DATA_CORRUPT
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
 Multi-part AEAD operations
 --------------------------
@@ -444,7 +444,7 @@ Multi-part AEAD operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be inactive.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INVALID_HANDLE
         ``key`` is not a valid key identifier.
     .. retval:: PSA_ERROR_NOT_PERMITTED
@@ -508,7 +508,7 @@ Multi-part AEAD operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be inactive.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INVALID_HANDLE
         ``key`` is not a valid key identifier.
     .. retval:: PSA_ERROR_NOT_PERMITTED
@@ -571,7 +571,7 @@ Multi-part AEAD operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active, and `psa_aead_set_nonce()` and `psa_aead_generate_nonce()` must not have been called yet.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         ``ad_length`` or ``plaintext_length`` are too large for the chosen algorithm.
     .. retval:: PSA_ERROR_NOT_SUPPORTED
@@ -614,7 +614,7 @@ Multi-part AEAD operations
 
         *   The operation state is not valid: it must be an active AEAD encryption operation, with no nonce set.
         *   The operation state is not valid: this is an algorithm which requires `psa_aead_set_lengths()` to be called before setting the nonce.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``nonce`` buffer is too small. `PSA_AEAD_NONCE_LENGTH()` or `PSA_AEAD_NONCE_MAX_SIZE` can be used to determine a sufficient buffer size.
     .. retval:: PSA_ERROR_INSUFFICIENT_ENTROPY
@@ -653,7 +653,7 @@ Multi-part AEAD operations
 
         *   The operation state is not valid: it must be active, with no nonce set.
         *   The operation state is not valid: this is an algorithm which requires `psa_aead_set_lengths()` to be called before setting the nonce.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         ``nonce_length`` is not valid for the chosen algorithm.
     .. retval:: PSA_ERROR_NOT_SUPPORTED
@@ -699,7 +699,7 @@ Multi-part AEAD operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active, have a nonce set, have lengths set if required by the algorithm, and `psa_aead_update()` must not have been called yet.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         Excess additional data: the total input length to `psa_aead_update_ad()` is greater than the additional data length that was previously specified with `psa_aead_set_lengths()`, or is too large for the chosen AEAD algorithm.
     .. retval:: PSA_ERROR_NOT_SUPPORTED
@@ -758,7 +758,7 @@ Multi-part AEAD operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active, have a nonce set, and have lengths set if required by the algorithm.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``output`` buffer is too small. `PSA_AEAD_UPDATE_OUTPUT_SIZE()` or `PSA_AEAD_UPDATE_OUTPUT_MAX_SIZE()` can be used to determine a sufficient buffer size.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
@@ -824,7 +824,7 @@ Multi-part AEAD operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be an active encryption operation with a nonce set.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``ciphertext`` or ``tag`` buffer is too small.
         `PSA_AEAD_FINISH_OUTPUT_SIZE()` or `PSA_AEAD_FINISH_OUTPUT_MAX_SIZE` can be used to determine the required ``ciphertext`` buffer size.
@@ -884,7 +884,7 @@ Multi-part AEAD operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be an active decryption operation with a nonce set.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``plaintext`` buffer is too small. `PSA_AEAD_VERIFY_OUTPUT_SIZE()` or `PSA_AEAD_VERIFY_OUTPUT_MAX_SIZE` can be used to determine a sufficient buffer size.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
@@ -930,7 +930,7 @@ Multi-part AEAD operations
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     Aborting an operation frees all associated resources except for the ``operation`` object itself. Once aborted, the operation object can be reused for another operation by calling `psa_aead_encrypt_setup()` or `psa_aead_decrypt_setup()` again.
 

--- a/doc/crypto/api/ops/cipher.rst
+++ b/doc/crypto/api/ops/cipher.rst
@@ -396,7 +396,7 @@ Single-part cipher functions
     .. retval:: PSA_ERROR_DATA_CORRUPT
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing, see :secref:`library-init`.
 
     This function encrypts a message with a random initialization vector (IV).
     The length of the IV is :code:`PSA_CIPHER_IV_LENGTH(key_type, alg)` where ``key_type`` is the type of ``key``.
@@ -460,7 +460,7 @@ Single-part cipher functions
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing, see :secref:`library-init`.
 
     This function decrypts a message encrypted with a symmetric cipher.
 
@@ -559,7 +559,7 @@ Multi-part cipher operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be inactive.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing, see :secref:`library-init`.
 
     The sequence of operations to encrypt a message with a symmetric cipher is as follows:
 
@@ -621,7 +621,7 @@ Multi-part cipher operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be inactive.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing, see :secref:`library-init`.
 
     The sequence of operations to decrypt a message with a symmetric cipher is as follows:
 
@@ -666,7 +666,7 @@ Multi-part cipher operations
 
         *   The cipher algorithm does not use an IV.
         *   The operation state is not valid: it must be active, with no IV set.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing, see :secref:`library-init`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``iv`` buffer is too small. `PSA_CIPHER_IV_LENGTH()` or `PSA_CIPHER_IV_MAX_SIZE` can be used to determine a sufficient buffer size.
     .. retval:: PSA_ERROR_INSUFFICIENT_ENTROPY
@@ -707,7 +707,7 @@ Multi-part cipher operations
 
         *   The cipher algorithm does not use an IV.
         *   The operation state is not valid: it must be an active cipher encrypt operation, with no IV set.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing, see :secref:`library-init`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The following conditions can result in this error:
 
@@ -763,7 +763,7 @@ Multi-part cipher operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active, with an IV set if required for the algorithm.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing, see :secref:`library-init`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``output`` buffer is too small. `PSA_CIPHER_UPDATE_OUTPUT_SIZE()` or `PSA_CIPHER_UPDATE_OUTPUT_MAX_SIZE()` can be used to determine a sufficient buffer size.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
@@ -818,7 +818,7 @@ Multi-part cipher operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active, with an IV set if required for the algorithm.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing, see :secref:`library-init`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``output`` buffer is too small. `PSA_CIPHER_FINISH_OUTPUT_SIZE()` or `PSA_CIPHER_FINISH_OUTPUT_MAX_SIZE` can be used to determine a sufficient buffer size.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
@@ -849,7 +849,7 @@ Multi-part cipher operations
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing, see :secref:`library-init`.
 
     Aborting an operation frees all associated resources except for the ``operation`` object itself. Once aborted, the operation object can be reused for another operation by calling `psa_cipher_encrypt_setup()` or `psa_cipher_decrypt_setup()` again.
 

--- a/doc/crypto/api/ops/hash.rst
+++ b/doc/crypto/api/ops/hash.rst
@@ -242,7 +242,7 @@ Single-part hashing functions
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     .. note::
         To verify the hash of a message against an expected value, use `psa_hash_compare()` instead.
@@ -283,7 +283,7 @@ Single-part hashing functions
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
 .. _hash-mp:
 
@@ -359,7 +359,7 @@ Multi-part hashing operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be inactive.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
@@ -402,7 +402,7 @@ Multi-part hashing operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The total input for the operation is too large for the hash algorithm.
     .. retval:: PSA_ERROR_NOT_SUPPORTED
@@ -437,7 +437,7 @@ Multi-part hashing operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``hash`` buffer is too small.
         `PSA_HASH_LENGTH()` can be used to determine a sufficient buffer size.
@@ -476,7 +476,7 @@ Multi-part hashing operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
@@ -503,7 +503,7 @@ Multi-part hashing operations
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     Aborting an operation frees all associated resources except for the ``operation`` object itself. Once aborted, the operation object can be reused for another operation by calling `psa_hash_setup()` again.
 
@@ -538,7 +538,7 @@ Multi-part hashing operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``hash_state`` buffer is too small.
         `PSA_HASH_SUSPEND_OUTPUT_SIZE()` or `PSA_HASH_SUSPEND_OUTPUT_MAX_SIZE` can be used to determine a sufficient buffer size.
@@ -604,7 +604,7 @@ Multi-part hashing operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be inactive.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
@@ -635,7 +635,7 @@ Multi-part hashing operations
 
         *   The ``source_operation`` state is not valid: it must be active.
         *   The ``target_operation`` state is not valid: it must be inactive.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY

--- a/doc/crypto/api/ops/key-agreement.rst
+++ b/doc/crypto/api/ops/key-agreement.rst
@@ -201,7 +201,7 @@ Standalone key agreement
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_INSUFFICIENT_STORAGE
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     A key agreement algorithm takes two inputs: a private key ``private_key``, and a public key ``peer_key``. The result of this function is a shared secret, returned as a derivation key. This key can be input to a key derivation operation using `psa_key_derivation_input_key()`.
 
@@ -263,7 +263,7 @@ Standalone key agreement
     .. retval:: PSA_ERROR_DATA_CORRUPT
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     A key agreement algorithm takes two inputs: a private key ``private_key``, and a public key ``peer_key``. The result of this function is a shared secret, returned in the ``output`` buffer.
 
@@ -301,7 +301,7 @@ Combining key agreement and key derivation
         The following conditions can result in this error:
 
         *   The operation state is not valid for this key agreement ``step``.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INVALID_HANDLE
         ``private_key`` is not a valid key identifier.
     .. retval:: PSA_ERROR_NOT_PERMITTED

--- a/doc/crypto/api/ops/key-derivation.rst
+++ b/doc/crypto/api/ops/key-derivation.rst
@@ -568,7 +568,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be inactive.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
 
     A key derivation algorithm takes some inputs and uses them to generate a byte stream in a deterministic way. This byte stream can be used to produce keys and other cryptographic material.
 
@@ -611,7 +611,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
 
     The capacity of a key derivation is the maximum number of bytes that it can return. Reading :math:`N` bytes of output from a key derivation operation reduces its capacity by at least :math:`N`. The capacity can be reduced by more than :math:`N` in the following situations:
@@ -638,7 +638,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
 
@@ -686,7 +686,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The operation state is not valid for this input ``step``. This can happen if the application provides a step out of order or repeats a step that may not be repeated.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
 
     Which inputs are required and in what order depends on the algorithm. Refer to the documentation of each key derivation or key agreement algorithm for information.
 
@@ -730,7 +730,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The operation state is not valid for this input ``step``. This can happen if the application provides a step out of order or repeats a step that may not be repeated.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
 
     Which inputs are required and in what order depends on the algorithm.
     However, when an algorithm requires a particular order, numeric inputs usually come first as they tend to be configuration parameters.
@@ -779,7 +779,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The operation state is not valid for this input ``step``. This can happen if the application provides a step out of order or repeats a step that may not be repeated.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
 
     Which inputs are required and in what order depends on the algorithm. Refer to the documentation of each key derivation or key agreement algorithm for information.
 
@@ -824,7 +824,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active, with all required input steps complete.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
@@ -900,7 +900,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active, with all required input steps complete.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_INSUFFICIENT_STORAGE
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
@@ -957,7 +957,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active, with all required input steps complete.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
 
     This function calculates output bytes from a key derivation algorithm and compares those bytes to an expected value.
     If the key derivation's output is viewed as a stream of bytes, this function destructively reads ``output_length`` bytes from the stream before comparing them with ``expected_output``.
@@ -1026,7 +1026,7 @@ Key derivation functions
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active, with all required input steps complete.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
 
 
     This function calculates output bytes from a key derivation algorithm and compares those bytes to an expected value, provided as key of type `PSA_KEY_TYPE_PASSWORD_HASH`.
@@ -1060,7 +1060,7 @@ Key derivation functions
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     Aborting an operation frees all associated resources except for the ``operation`` object itself. Once aborted, the operation object can be reused for another operation by calling `psa_key_derivation_setup()` again.
 

--- a/doc/crypto/api/ops/mac.rst
+++ b/doc/crypto/api/ops/mac.rst
@@ -227,7 +227,7 @@ Single-part MAC functions
     .. retval:: PSA_ERROR_DATA_CORRUPT
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     .. note::
         To verify the MAC of a message against an expected value, use `psa_mac_verify()` instead. Beware that comparing integrity or authenticity data such as MAC values with a function such as ``memcmp()`` is risky because the time taken by the comparison might leak information about the MAC value which could allow an attacker to guess a valid MAC and thereby bypass security controls.
@@ -280,7 +280,7 @@ Single-part MAC functions
     .. retval:: PSA_ERROR_DATA_CORRUPT
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
 Multi-part MAC operations
 -------------------------
@@ -373,7 +373,7 @@ Multi-part MAC operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be inactive.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
 
     This function sets up the calculation of the message authentication code (MAC) of a byte string. To verify the MAC of a message against an expected value, use `psa_mac_verify_setup()` instead.
 
@@ -436,7 +436,7 @@ Multi-part MAC operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be inactive.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
 
     This function sets up the verification of the message authentication code (MAC) of a byte string against an expected value.
 
@@ -478,7 +478,7 @@ Multi-part MAC operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be active.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INVALID_ARGUMENT
         The total input for the operation is too large for the MAC algorithm.
     .. retval:: PSA_ERROR_NOT_SUPPORTED
@@ -522,7 +522,7 @@ Multi-part MAC operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be an active mac sign operation.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_BUFFER_TOO_SMALL
         The size of the ``mac`` buffer is too small.
         `PSA_MAC_LENGTH()` or `PSA_MAC_MAX_SIZE` can be used to determine a sufficient buffer size.
@@ -564,7 +564,7 @@ Multi-part MAC operations
         The following conditions can result in this error:
 
         *   The operation state is not valid: it must be an active mac verify operation.
-        *   The library requires initializing by a call to `psa_crypto_init()`.
+        *   The library requires initializing. See :secref:`library-init`.
     .. retval:: PSA_ERROR_INSUFFICIENT_MEMORY
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
@@ -594,7 +594,7 @@ Multi-part MAC operations
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     Aborting an operation frees all associated resources except for the ``operation`` object itself. Once aborted, the operation object can be reused for another operation by calling `psa_mac_sign_setup()` or `psa_mac_verify_setup()` again.
 

--- a/doc/crypto/api/ops/pk-encryption.rst
+++ b/doc/crypto/api/ops/pk-encryption.rst
@@ -118,7 +118,7 @@ Asymmetric encryption functions
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_INSUFFICIENT_ENTROPY
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     *   For `PSA_ALG_RSA_PKCS1V15_CRYPT`, no salt is supported.
 
@@ -186,7 +186,7 @@ Asymmetric encryption functions
     .. retval:: PSA_ERROR_INVALID_PADDING
         The algorithm uses padding, and the input does not contain valid padding.
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     *   For `PSA_ALG_RSA_PKCS1V15_CRYPT`, no salt is supported.
 

--- a/doc/crypto/api/ops/rng.rst
+++ b/doc/crypto/api/ops/rng.rst
@@ -32,7 +32,7 @@ Random number generation
     .. retval:: PSA_ERROR_COMMUNICATION_FAILURE
     .. retval:: PSA_ERROR_CORRUPTION_DETECTED
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     .. warning::
         This function **can** fail! Callers MUST check the return status and MUST NOT use the content of the output buffer if the return status is not :code:`PSA_SUCCESS`.

--- a/doc/crypto/api/ops/signature.rst
+++ b/doc/crypto/api/ops/signature.rst
@@ -407,7 +407,7 @@ Asymmetric signature functions
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_INSUFFICIENT_ENTROPY
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     ..  note::
         To perform a multi-part hash-and-sign signature algorithm, first use a :ref:`multi-part hash operation <hash-mp>` and then pass the resulting hash to `psa_sign_hash()`. :code:`PSA_ALG_GET_HASH(alg)` can be used to determine the hash algorithm to use.
@@ -459,7 +459,7 @@ Asymmetric signature functions
     .. retval:: PSA_ERROR_DATA_CORRUPT
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     ..  note::
         To perform a multi-part hash-and-sign signature verification algorithm, first use a :ref:`multi-part hash operation <hash-mp>` to hash the message and then pass the resulting hash to `psa_verify_hash()`. :code:`PSA_ALG_GET_HASH(alg)` can be used to determine the hash algorithm to use.
@@ -522,7 +522,7 @@ Asymmetric signature functions
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_INSUFFICIENT_ENTROPY
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     With most signature algorithms that follow the hash-and-sign paradigm, the ``hash`` input to this function is the hash of the message to sign. The algorithm used to compute this hash is encoded in the signature algorithm. For such algorithms, ``hash_length`` must equal the length of the hash output, and the following condition is true:
 
@@ -588,7 +588,7 @@ Asymmetric signature functions
     .. retval:: PSA_ERROR_DATA_CORRUPT
     .. retval:: PSA_ERROR_DATA_INVALID
     .. retval:: PSA_ERROR_BAD_STATE
-        The library requires initializing by a call to `psa_crypto_init()`.
+        The library requires initializing. See :secref:`library-init`.
 
     With most signature algorithms that follow the hash-and-sign paradigm, the ``hash`` input to this function is the hash of the message to verify. The algorithm used to compute this hash is encoded in the signature algorithm. For such algorithms, ``hash_length`` must equal the length of the hash output, and the following condition is true:
 

--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -21,6 +21,8 @@ Changes to the API
 
 *   Added `PSA_EXPORT_ASYMMETRIC_KEY_MAX_SIZE` to evaluate the export buffer size for any asymmetric key pair or public key.
 
+*   Added support for partial initialization of the implementation. See :secref:`library-init`.
+
 Other changes
 ~~~~~~~~~~~~~
 


### PR DESCRIPTION
See #16 for discussion of this API, which enables partial initialization of the library. This is useful in constrained contexts, for example during early boot, when not all library functionality is required to support the application use case.

Fixes #16