### PR TITLE
Clarified flexibility for unsupported parameter values

### DIFF
--- a/doc/crypto/api/library/status.rst
+++ b/doc/crypto/api/library/status.rst
@@ -45,7 +45,7 @@ These definitions must be available to an application that includes the :file:`p
 Common error codes
 ^^^^^^^^^^^^^^^^^^
 
-Some of the common status codes have a more precise meaning when returned by a function in the |API|, compared to the definitions in `[PSA-STAT]`.
+Some of the common status codes have a more precise meaning when returned by a function in the |API|, compared to the definitions in `[PSA-STAT]`. See also :secref:`error-handling`.
 
 .. list-table::
     :class: longtable
@@ -54,6 +54,16 @@ Some of the common status codes have a more precise meaning when returned by a f
 
     * - Error code
       - Meaning in the |API|
+
+    * - :code:`PSA_ERROR_NOT_SUPPORTED`
+      - `[PSA-STAT]` recommends the use of :code:`PSA_ERROR_INVALID_ARGUMENT` for invalid parameter values.
+
+        In the |API|, this is relaxed for algorithm identifier and key parameters, when either :code:`PSA_ERROR_INVALID_ARGUMENT` or :code:`PSA_ERROR_NOT_SUPPORTED` can be returned.
+
+    * - :code:`PSA_ERROR_INVALID_ARGUMENT`
+      - `[PSA-STAT]` recommends the use of :code:`PSA_ERROR_NOT_SUPPORTED` for unsupported parameter values.
+
+        In the |API|, either :code:`PSA_ERROR_INVALID_ARGUMENT` or :code:`PSA_ERROR_NOT_SUPPORTED` can be returned when unsupported algorithm identifier or key parameters are used.
 
     * - :code:`PSA_ERROR_INVALID_HANDLE`
       - A key identifier does not refer to an existing key. See also :secref:`key-ids`.

--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -26,6 +26,7 @@ Other changes
 
 *   Integrated the PAKE Extension with the main specification for the |API|.
 *   Moved the documentation of key formats and key derivation procedures to sub-sections within each key type.
+*   Clarified the flexibility for an implementation to return either :code:`PSA_ERROR_NOT_SUPPORTED` or :code:`PSA_ERROR_INVALID_ARGUMENT` when provided with unsupported algorithm identifier or key parameters.
 
 Changes between *1.2.0* and *1.2.1*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/crypto/overview/conventions.rst
+++ b/doc/crypto/overview/conventions.rst
@@ -116,6 +116,14 @@ of error code is considered an implementation quality issue. Different
 implementations can make different choices, for example to favor code size over
 ease of debugging or vice versa.
 
+In particular, in the |API|, there are many conditions where the specification permits a function to return either :code:`PSA_ERROR_INVALID_ARGUMENT` or :code:`PSA_ERROR_NOT_SUPPORTED`.
+For example, `psa_hash_compute()` is passed a hash algorithm that the implementation does not support, it is :scterm:`implementation defined` whether :code:`PSA_ERROR_INVALID_ARGUMENT` or :code:`PSA_ERROR_NOT_SUPPORTED` is returned.
+
+.. rationale::
+
+    This flexibility supports the `scalability design goal<scalable>`.
+    It permits implementations to not check whether unsupported algorithm identifier and key type values are valid or invalid.
+
 If the behavior is undefined, for example, if a function receives an invalid
 pointer as a parameter, this specification makes no guarantee that the function
 will return an error. Implementations are encouraged to return an error or halt


### PR DESCRIPTION
Provide additional information about the flexibility in the Crypto API in relation to the use of `PSA_ERROR_INVALID_ARGUMENT` and `PSA_ERROR_NOT_SUPPORTED`.