### PR TITLE
Fix inconsistent whitespace in API prototypes

### DIFF
--- a/doc/crypto/api.db/psa/crypto.h
+++ b/doc/crypto/api.db/psa/crypto.h
@@ -509,11 +509,11 @@ psa_status_t psa_export_public_key(psa_key_id_t key,
                                    size_t * data_length);
 psa_status_t psa_generate_key(const psa_key_attributes_t * attributes,
                               psa_key_id_t * key);
-psa_status_t psa_generate_key_custom(const psa_key_attributes_t *attributes,
-                                     const psa_custom_key_parameters_t *custom,
-                                     const uint8_t *custom_data,
+psa_status_t psa_generate_key_custom(const psa_key_attributes_t * attributes,
+                                     const psa_custom_key_parameters_t * custom,
+                                     const uint8_t * custom_data,
                                      size_t custom_data_length,
-                                     mbedtls_svc_key_id_t *key);
+                                     mbedtls_svc_key_id_t * key);
 psa_status_t psa_generate_random(uint8_t * output,
                                  size_t output_size);
 psa_algorithm_t psa_get_key_algorithm(const psa_key_attributes_t * attributes);
@@ -594,18 +594,18 @@ psa_status_t psa_key_derivation_output_bytes(psa_key_derivation_operation_t * op
 psa_status_t psa_key_derivation_output_key(const psa_key_attributes_t * attributes,
                                            psa_key_derivation_operation_t * operation,
                                            psa_key_id_t * key);
-psa_status_t psa_key_derivation_output_key_custom(const psa_key_attributes_t *attributes,
-                                                  psa_key_derivation_operation_t *operation,
-                                                  const psa_custom_key_parameters_t *custom,
-                                                  const uint8_t *custom_data,
+psa_status_t psa_key_derivation_output_key_custom(const psa_key_attributes_t * attributes,
+                                                  psa_key_derivation_operation_t * operation,
+                                                  const psa_custom_key_parameters_t * custom,
+                                                  const uint8_t * custom_data,
                                                   size_t custom_data_length,
-                                                  mbedtls_svc_key_id_t *key);
+                                                  mbedtls_svc_key_id_t * key);
 psa_status_t psa_key_derivation_set_capacity(psa_key_derivation_operation_t * operation,
                                              size_t capacity);
 psa_status_t psa_key_derivation_setup(psa_key_derivation_operation_t * operation,
                                       psa_algorithm_t alg);
 psa_status_t psa_key_derivation_verify_bytes(psa_key_derivation_operation_t * operation,
-                                             const uint8_t *expected_output,
+                                             const uint8_t * expected_output,
                                              size_t output_length);
 psa_status_t psa_key_derivation_verify_key(psa_key_derivation_operation_t * operation,
                                            psa_key_id_t expected);
@@ -651,33 +651,33 @@ void psa_pake_cs_set_key_confirmation(psa_pake_cipher_suite_t* cipher_suite,
                                       uint32_t key_confirmation);
 void psa_pake_cs_set_primitive(psa_pake_cipher_suite_t* cipher_suite,
                                psa_pake_primitive_t primitive);
-psa_status_t psa_pake_get_shared_key(psa_pake_operation_t *operation,
+psa_status_t psa_pake_get_shared_key(psa_pake_operation_t * operation,
                                      const psa_key_attributes_t * attributes,
                                      psa_key_id_t * key);
-psa_status_t psa_pake_input(psa_pake_operation_t *operation,
+psa_status_t psa_pake_input(psa_pake_operation_t * operation,
                             psa_pake_step_t step,
-                            const uint8_t *input,
+                            const uint8_t * input,
                             size_t input_length);
 psa_pake_operation_t psa_pake_operation_init(void);
-psa_status_t psa_pake_output(psa_pake_operation_t *operation,
+psa_status_t psa_pake_output(psa_pake_operation_t * operation,
                              psa_pake_step_t step,
-                             uint8_t *output,
+                             uint8_t * output,
                              size_t output_size,
-                             size_t *output_length);
-psa_status_t psa_pake_set_context(psa_pake_operation_t *operation,
-                                  const uint8_t *context,
+                             size_t * output_length);
+psa_status_t psa_pake_set_context(psa_pake_operation_t * operation,
+                                  const uint8_t * context,
                                   size_t context_len);
-psa_status_t psa_pake_set_peer(psa_pake_operation_t *operation,
-                               const uint8_t *peer_id,
+psa_status_t psa_pake_set_peer(psa_pake_operation_t * operation,
+                               const uint8_t * peer_id,
                                size_t peer_id_len);
-psa_status_t psa_pake_set_role(psa_pake_operation_t *operation,
+psa_status_t psa_pake_set_role(psa_pake_operation_t * operation,
                                psa_pake_role_t role);
-psa_status_t psa_pake_set_user(psa_pake_operation_t *operation,
-                               const uint8_t *user_id,
+psa_status_t psa_pake_set_user(psa_pake_operation_t * operation,
+                               const uint8_t * user_id,
                                size_t user_id_len);
-psa_status_t psa_pake_setup(psa_pake_operation_t *operation,
+psa_status_t psa_pake_setup(psa_pake_operation_t * operation,
                             psa_key_id_t password_key,
-                            const psa_pake_cipher_suite_t *cipher_suite);
+                            const psa_pake_cipher_suite_t * cipher_suite);
 psa_status_t psa_purge_key(psa_key_id_t key);
 psa_status_t psa_raw_key_agreement(psa_algorithm_t alg,
                                    psa_key_id_t private_key,

--- a/doc/crypto/api/keys/management.rst
+++ b/doc/crypto/api/keys/management.rst
@@ -258,15 +258,15 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
             This is an input parameter: it is not updated with the final key attributes.
             The final attributes of the new key can be queried by calling `psa_get_key_attributes()` with the key's identifier.
 
-    .. param:: const psa_custom_key_parameters_t *custom
+    .. param:: const psa_custom_key_parameters_t * custom
         Customized production parameters for the key generation.
 
         When this is `PSA_CUSTOM_KEY_PARAMETERS_INIT` with ``custom_data_length == 0``, this function is equivalent to `psa_generate_key()`.
-    .. param:: const uint8_t *custom_data
+    .. param:: const uint8_t * custom_data
         A buffer containing additional variable-sized production parameters.
     .. param:: size_t custom_data_length
         Length of ``custom_data`` in bytes.
-    .. param:: mbedtls_svc_key_id_t *key
+    .. param:: mbedtls_svc_key_id_t * key
         On success, an identifier for the newly created key.
         For persistent keys, this is the key identifier defined in ``attributes``.
         `PSA_KEY_ID_NULL` on failure.

--- a/doc/crypto/api/ops/key-derivation.rst
+++ b/doc/crypto/api/ops/key-derivation.rst
@@ -967,18 +967,18 @@ Key derivation functions
             This is an input parameter: it is not updated with the final key attributes.
             The final attributes of the new key can be queried by calling `psa_get_key_attributes()` with the key's identifier.
 
-    .. param:: psa_key_derivation_operation_t *operation
+    .. param:: psa_key_derivation_operation_t * operation
         The key derivation operation object to read from.
-    .. param:: const psa_custom_key_parameters_t *custom
+    .. param:: const psa_custom_key_parameters_t * custom
         Customized production parameters for the key derivation.
 
         When this is `PSA_CUSTOM_KEY_PARAMETERS_INIT` with ``custom_data_length == 0``,
         this function is equivalent to `psa_key_derivation_output_key()`.
-    .. param:: const uint8_t *custom_data
+    .. param:: const uint8_t * custom_data
         A buffer containing additional variable-sized production parameters.
     .. param:: size_t custom_data_length
         Length of ``custom_data`` in bytes.
-    .. param:: mbedtls_svc_key_id_t *key
+    .. param:: mbedtls_svc_key_id_t * key
         On success, an identifier for the newly created key.
         For persistent keys, this is the key identifier defined in ``attributes``.
         `PSA_KEY_ID_NULL` on failure.
@@ -1042,7 +1042,7 @@ Key derivation functions
 
     .. param:: psa_key_derivation_operation_t * operation
         The key derivation operation object to read from.
-    .. param:: const uint8_t *expected_output
+    .. param:: const uint8_t * expected_output
         Buffer containing the expected derivation output.
     .. param:: size_t output_length
         Length of the expected output. This is also the number of bytes that will be read.

--- a/doc/crypto/api/ops/pake.rst
+++ b/doc/crypto/api/ops/pake.rst
@@ -619,7 +619,7 @@ Multi-part PAKE operations
     .. summary::
         Setup a password-authenticated key exchange.
 
-    .. param:: psa_pake_operation_t *operation
+    .. param:: psa_pake_operation_t * operation
         The operation object to set up.
         It must have been initialized as per the documentation for `psa_pake_operation_t` and not yet in use.
     .. param:: psa_key_id_t password_key
@@ -630,7 +630,7 @@ Multi-part PAKE operations
         Refer to the documentation of individual PAKE algorithms for more information.
 
         The key must permit the usage :code:`PSA_KEY_USAGE_DERIVE`.
-    .. param:: const psa_pake_cipher_suite_t *cipher_suite
+    .. param:: const psa_pake_cipher_suite_t * cipher_suite
         The cipher suite to use.
         A PAKE cipher suite fully characterizes a PAKE algorithm, including the PAKE algorithm.
 
@@ -704,7 +704,7 @@ Multi-part PAKE operations
     .. summary::
         Set the application role for a password-authenticated key exchange.
 
-    .. param:: psa_pake_operation_t *operation
+    .. param:: psa_pake_operation_t * operation
         Active PAKE operation.
     .. param:: psa_pake_role_t role
         A value of type `psa_pake_role_t` indicating the application role in the PAKE algorithm.
@@ -744,9 +744,9 @@ Multi-part PAKE operations
     .. summary::
         Set the user ID for a password-authenticated key exchange.
 
-    .. param:: psa_pake_operation_t *operation
+    .. param:: psa_pake_operation_t * operation
         Active PAKE operation.
-    .. param:: const uint8_t *user_id
+    .. param:: const uint8_t * user_id
         The user ID to authenticate with.
     .. param:: size_t user_id_len
         Size of the ``user_id`` buffer in bytes.
@@ -778,9 +778,9 @@ Multi-part PAKE operations
     .. summary::
         Set the peer ID for a password-authenticated key exchange.
 
-    .. param:: psa_pake_operation_t *operation
+    .. param:: psa_pake_operation_t * operation
         Active PAKE operation.
-    .. param:: const uint8_t *peer_id
+    .. param:: const uint8_t * peer_id
         The peer's ID to authenticate.
     .. param:: size_t peer_id_len
         Size of the ``peer_id`` buffer in bytes.
@@ -813,9 +813,9 @@ Multi-part PAKE operations
     .. summary::
         Set the context data for a password-authenticated key exchange.
 
-    .. param:: psa_pake_operation_t *operation
+    .. param:: psa_pake_operation_t * operation
         Active PAKE operation.
-    .. param:: const uint8_t *context
+    .. param:: const uint8_t * context
         The peer's ID to authenticate.
     .. param:: size_t context_len
         Size of the ``context`` buffer in bytes.
@@ -847,11 +847,11 @@ Multi-part PAKE operations
     .. summary::
         Get output for a step of a password-authenticated key exchange.
 
-    .. param:: psa_pake_operation_t *operation
+    .. param:: psa_pake_operation_t * operation
         Active PAKE operation.
     .. param:: psa_pake_step_t step
         The step of the algorithm for which the output is requested.
-    .. param:: uint8_t *output
+    .. param:: uint8_t * output
         Buffer where the output is to be written.
         The format of the output depends on the ``step``, see :secref:`pake-steps`.
     .. param:: size_t output_size
@@ -860,7 +860,7 @@ Multi-part PAKE operations
 
         *   A sufficient output size is :code:`PSA_PAKE_OUTPUT_SIZE(alg, primitive, step)` where ``alg`` and ``primitive`` are the PAKE algorithm and primitive in the operation's cipher suite, and ``step`` is the output step.
         *   `PSA_PAKE_OUTPUT_MAX_SIZE` evaluates to the maximum output size of any supported PAKE algorithm, primitive and step.
-    .. param:: size_t *output_length
+    .. param:: size_t * output_length
         On success, the number of bytes of the returned output.
 
     .. return:: psa_status_t
@@ -899,11 +899,11 @@ Multi-part PAKE operations
     .. summary::
         Provide input for a step of a password-authenticated key exchange.
 
-    .. param:: psa_pake_operation_t *operation
+    .. param:: psa_pake_operation_t * operation
         Active PAKE operation.
     .. param:: psa_pake_step_t step
         The step for which the input is provided.
-    .. param:: const uint8_t *input
+    .. param:: const uint8_t * input
         Buffer containing the input.
         The format of the input depends on the ``step``, see :secref:`pake-steps`.
     .. param:: size_t input_length
@@ -950,7 +950,7 @@ Multi-part PAKE operations
     .. summary::
         Extract the shared secret from the PAKE as a key.
 
-    .. param:: psa_pake_operation_t *operation
+    .. param:: psa_pake_operation_t * operation
         Active PAKE operation.
     .. param:: const psa_key_attributes_t * attributes
         The attributes for the new key.


### PR DESCRIPTION
I noticed that most of the pointer parameters use `type * parameter` spacing, but a handful us `type *parameter` spacing in the API prototypes.

This changes all the latter to match the former style.