### PR TITLE
Fix issues in the reference header files

### DIFF
--- a/headers/attestation/1.0/psa/initial_attestation.h
+++ b/headers/attestation/1.0/psa/initial_attestation.h
@@ -48,7 +48,7 @@ extern "C" {
 
 /**
  * @brief Retrieve the Initial Attestation Token.
- * 
+ *
  * @param auth_challenge Buffer with a challenge object.
  * @param challenge_size Size of the buffer auth_challenge in bytes.
  * @param token_buf      Output buffer where the attestation token is to be
@@ -64,7 +64,7 @@ psa_status_t psa_initial_attest_get_token(const uint8_t *auth_challenge,
 
 /**
  * @brief Calculate the size of an Initial Attestation Token.
- * 
+ *
  * @param challenge_size Size of a challenge object in bytes.
  * @param token_size     Output variable for the token size.
  */

--- a/headers/crypto/1.1/psa/crypto-pake.h
+++ b/headers/crypto/1.1/psa/crypto-pake.h
@@ -11,9 +11,9 @@
 /**
  * @brief Whether the specified algorithm is a password-authenticated key
  *        exchange.
- * 
+ *
  * @param alg An algorithm identifier: a value of type psa_algorithm_t.
- * 
+ *
  * @return 1 if alg is a password-authenticated key exchange (PAKE) algorithm, 0
  *         otherwise.
  */
@@ -52,12 +52,12 @@ typedef uint32_t psa_pake_primitive_t;
 
 /**
  * @brief Construct a PAKE primitive from type, family and bit-size.
- * 
+ *
  * @param pake_type   The type of the primitive: a value of type
  *                    psa_pake_primitive_type_t.
  * @param pake_family The family of the primitive.
  * @param pake_bits   The bit-size of the primitive: a value of type size_t.
- * 
+ *
  * @return The constructed primitive value.
  */
 #define PSA_PAKE_PRIMITIVE(pake_type, pake_family, pake_bits) \
@@ -81,16 +81,16 @@ psa_pake_cipher_suite_t psa_pake_cipher_suite_init(void);
 
 /**
  * @brief Retrieve the PAKE algorithm from a PAKE cipher suite.
- * 
+ *
  * @param cipher_suite The cipher suite object to query.
- * 
+ *
  * @return The PAKE algorithm stored in the cipher suite object.
  */
 psa_algorithm_t psa_pake_cs_get_algorithm(const psa_pake_cipher_suite_t* cipher_suite);
 
 /**
  * @brief Declare the PAKE algorithm for the cipher suite.
- * 
+ *
  * @param cipher_suite The cipher suite object to write to.
  * @param alg          The PAKE algorithm to write: a value of type
  *                     psa_algorithm_t such that PSA_ALG_IS_PAKE(alg) is true.
@@ -100,16 +100,16 @@ void psa_pake_cs_set_algorithm(psa_pake_cipher_suite_t* cipher_suite,
 
 /**
  * @brief Retrieve the primitive from a PAKE cipher suite.
- * 
+ *
  * @param cipher_suite The cipher suite object to query.
- * 
+ *
  * @return The primitive stored in the cipher suite object.
  */
 psa_pake_primitive_t psa_pake_cs_get_primitive(const psa_pake_cipher_suite_t* cipher_suite);
 
 /**
  * @brief Declare the primitive for a PAKE cipher suite.
- * 
+ *
  * @param cipher_suite The cipher suite object to write to.
  * @param primitive    The PAKE primitive to write: a value of type
  *                     psa_pake_primitive_t.
@@ -119,16 +119,16 @@ void psa_pake_cs_set_primitive(psa_pake_cipher_suite_t* cipher_suite,
 
 /**
  * @brief Retrieve the hash algorithm from a PAKE cipher suite.
- * 
+ *
  * @param cipher_suite The cipher suite object to query.
- * 
+ *
  * @return The hash algorithm stored in the cipher suite object.
  */
 psa_pake_primitive_t psa_pake_cs_get_hash(const psa_pake_cipher_suite_t* cipher_suite);
 
 /**
  * @brief Declare the hash algorithm for a PAKE cipher suite.
- * 
+ *
  * @param cipher_suite The cipher suite object to write to.
  * @param hash_alg     The hash algorithm to write: a value of type
  *                     psa_algorithm_t such that PSA_ALG_IS_HASH(hash_alg) is
@@ -205,7 +205,7 @@ psa_pake_operation_t psa_pake_operation_init(void);
 
 /**
  * @brief Set the session information for a password-authenticated key exchange.
- * 
+ *
  * @param operation    The operation object to set up.
  * @param cipher_suite The cipher suite to use.
  */
@@ -215,7 +215,7 @@ psa_status_t psa_pake_setup(psa_pake_operation_t *operation,
 /**
  * @brief Set the password for a password-authenticated key exchange using a
  *        key.
- * 
+ *
  * @param operation Active PAKE operation.
  * @param password  Identifier of the key holding the password or a value
  *                  derived from the password.
@@ -225,7 +225,7 @@ psa_status_t psa_pake_set_password_key(psa_pake_operation_t *operation,
 
 /**
  * @brief Set the user ID for a password-authenticated key exchange.
- * 
+ *
  * @param operation   Active PAKE operation.
  * @param user_id     The user ID to authenticate with.
  * @param user_id_len Size of the user_id buffer in bytes.
@@ -236,7 +236,7 @@ psa_status_t psa_pake_set_user(psa_pake_operation_t *operation,
 
 /**
  * @brief Set the peer ID for a password-authenticated key exchange.
- * 
+ *
  * @param operation   Active PAKE operation.
  * @param peer_id     The peer's ID to authenticate.
  * @param peer_id_len Size of the peer_id buffer in bytes.
@@ -247,7 +247,7 @@ psa_status_t psa_pake_set_peer(psa_pake_operation_t *operation,
 
 /**
  * @brief Set the application role for a password-authenticated key exchange.
- * 
+ *
  * @param operation Active PAKE operation.
  * @param role      A value of type psa_pake_role_t indicating the application
  *                  role in the PAKE algorithm.
@@ -257,7 +257,7 @@ psa_status_t psa_pake_set_role(psa_pake_operation_t *operation,
 
 /**
  * @brief Get output for a step of a password-authenticated key exchange.
- * 
+ *
  * @param operation     Active PAKE operation.
  * @param step          The step of the algorithm for which the output is
  *                      requested.
@@ -273,7 +273,7 @@ psa_status_t psa_pake_output(psa_pake_operation_t *operation,
 
 /**
  * @brief Provide input for a step of a password-authenticated key exchange.
- * 
+ *
  * @param operation    Active PAKE operation.
  * @param step         The step for which the input is provided.
  * @param input        Buffer containing the input.
@@ -287,7 +287,7 @@ psa_status_t psa_pake_input(psa_pake_operation_t *operation,
 /**
  * @brief Pass the implicitly confirmed shared secret from a PAKE into a key
  *        derivation operation.
- * 
+ *
  * @param operation Active PAKE operation.
  * @param output    A key derivation operation that is ready for an input step
  *                  of type PSA_KEY_DERIVATION_INPUT_SECRET.
@@ -297,21 +297,21 @@ psa_status_t psa_pake_get_implicit_key(psa_pake_operation_t *operation,
 
 /**
  * @brief Abort a PAKE operation.
- * 
+ *
  * @param operation Initialized PAKE operation.
  */
 psa_status_t psa_pake_abort(psa_pake_operation_t * operation);
 
 /**
  * @brief Sufficient output buffer size for psa_pake_output(), in bytes.
- * 
+ *
  * @param alg         A PAKE algorithm: a value of type psa_algorithm_t such
  *                    that PSA_ALG_IS_PAKE(alg) is true.
  * @param primitive   A primitive of type psa_pake_primitive_t that is
  *                    compatible with algorithm alg.
  * @param output_step A value of type psa_pake_step_t that is valid for the
  *                    algorithm alg.
- * 
+ *
  * @return A sufficient output buffer size for the specified PAKE algorithm,
  *         primitive, and output step.
  */
@@ -326,14 +326,14 @@ psa_status_t psa_pake_abort(psa_pake_operation_t * operation);
 
 /**
  * @brief Sufficient buffer size for inputs to psa_pake_input().
- * 
+ *
  * @param alg        A PAKE algorithm: a value of type psa_algorithm_t such that
  *                   PSA_ALG_IS_PAKE(alg) is true.
  * @param primitive  A primitive of type psa_pake_primitive_t that is compatible
  *                   with algorithm alg.
  * @param input_step A value of type psa_pake_step_t that is valid for the
  *                   algorithm alg.
- * 
+ *
  * @return A sufficient buffer size for the specified PAKE algorithm, primitive,
  *         and input step.
  */

--- a/headers/crypto/1.1/psa/crypto.h
+++ b/headers/crypto/1.1/psa/crypto.h
@@ -2199,22 +2199,22 @@ psa_status_t psa_aead_abort(psa_aead_operation_t * operation);
 #define PSA_ALG_HKDF_EXPAND(hash_alg) /* specification-defined value */
 
 /**
- * @brief Macro to build a TLS-1.
+ * @brief Macro to build a TLS-1.2 PRF algorithm.
  *
  * @param hash_alg A hash algorithm: a value of type psa_algorithm_t such that
  *                 PSA_ALG_IS_HASH(hash_alg) is true.
  *
- * @return The corresponding TLS-1.
+ * @return The corresponding TLS-1.2 PRF algorithm.
  */
 #define PSA_ALG_TLS12_PRF(hash_alg) /* specification-defined value */
 
 /**
- * @brief Macro to build a TLS-1.
+ * @brief Macro to build a TLS-1.2 PSK-to-MasterSecret algorithm.
  *
  * @param hash_alg A hash algorithm: a value of type psa_algorithm_t such that
  *                 PSA_ALG_IS_HASH(hash_alg) is true.
  *
- * @return The corresponding TLS-1.
+ * @return The corresponding TLS-1.2 PSK to MS algorithm.
  */
 #define PSA_ALG_TLS12_PSK_TO_MS(hash_alg) /* specification-defined value */
 
@@ -2459,20 +2459,20 @@ psa_status_t psa_key_derivation_abort(psa_key_derivation_operation_t * operation
 #define PSA_ALG_IS_HKDF_EXPAND(alg) /* specification-defined value */
 
 /**
- * @brief Whether the specified algorithm is a TLS-1.
+ * @brief Whether the specified algorithm is a TLS-1.2 PRF algorithm.
  *
  * @param alg An algorithm identifier: a value of type psa_algorithm_t.
  *
- * @return 1 if alg is a TLS-1.
+ * @return 1 if alg is a TLS-1.2 PRF algorithm, 0 otherwise.
  */
 #define PSA_ALG_IS_TLS12_PRF(alg) /* specification-defined value */
 
 /**
- * @brief Whether the specified algorithm is a TLS-1.
+ * @brief Whether the specified algorithm is a TLS-1.2 PSK to MS algorithm.
  *
  * @param alg An algorithm identifier: a value of type psa_algorithm_t.
  *
- * @return 1 if alg is a TLS-1.
+ * @return 1 if alg is a TLS-1.2 PSK to MS algorithm, 0 otherwise.
  */
 #define PSA_ALG_IS_TLS12_PSK_TO_MS(alg) /* specification-defined value */
 
@@ -2493,22 +2493,22 @@ psa_status_t psa_key_derivation_abort(psa_key_derivation_operation_t * operation
 
 /**
  * @brief This macro returns the maximum supported length of the PSK for the
- *        TLS-1.
+ *        TLS-1.2 PSK-to-MS key derivation.
  */
 #define PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE /* implementation-defined value */
 
 /**
- * @brief The RSA PKCS#1 v1.
+ * @brief The RSA PKCS#1 v1.5 message signature scheme, with hashing.
  *
  * @param hash_alg A hash algorithm: a value of type psa_algorithm_t such that
  *                 PSA_ALG_IS_HASH(hash_alg) is true.
  *
- * @return The corresponding RSA PKCS#1 v1.
+ * @return The corresponding RSA PKCS#1 v1.5 signature algorithm.
  */
 #define PSA_ALG_RSA_PKCS1V15_SIGN(hash_alg) /* specification-defined value */
 
 /**
- * @brief The raw RSA PKCS#1 v1.
+ * @brief The raw RSA PKCS#1 v1.5 signature algorithm, without hashing.
  */
 #define PSA_ALG_RSA_PKCS1V15_SIGN_RAW ((psa_algorithm_t) 0x06000200)
 
@@ -2680,11 +2680,12 @@ psa_status_t psa_verify_hash(psa_key_id_t key,
 #define PSA_ALG_IS_SIGN_HASH(alg) /* specification-defined value */
 
 /**
- * @brief Whether the specified algorithm is an RSA PKCS#1 v1.
+ * @brief Whether the specified algorithm is an RSA PKCS#1 v1.5 signature
+ *        algorithm.
  *
  * @param alg An algorithm identifier: a value of type psa_algorithm_t.
  *
- * @return 1 if alg is an RSA PKCS#1 v1.
+ * @return 1 if alg is an RSA PKCS#1 v1.5 signature algorithm, 0 otherwise.
  */
 #define PSA_ALG_IS_RSA_PKCS1V15_SIGN(alg) /* specification-defined value */
 
@@ -2794,7 +2795,7 @@ psa_status_t psa_verify_hash(psa_key_id_t key,
 #define PSA_SIGNATURE_MAX_SIZE /* implementation-defined value */
 
 /**
- * @brief The RSA PKCS#1 v1.
+ * @brief The RSA PKCS#1 v1.5 asymmetric encryption algorithm.
  */
 #define PSA_ALG_RSA_PKCS1V15_CRYPT ((psa_algorithm_t)0x07000200)
 

--- a/headers/crypto/1.2/psa/crypto.h
+++ b/headers/crypto/1.2/psa/crypto.h
@@ -917,7 +917,8 @@ psa_status_t psa_export_public_key(psa_key_id_t key,
 #define PSA_ALG_RIPEMD160 ((psa_algorithm_t)0x02000004)
 
 /**
- * @brief The Zigbee 1.
+ * @brief The Zigbee 1.0 hash function based on a Matyas-Meyer-Oseas (MMO)
+ *        construction using AES-128.
  */
 #define PSA_ALG_AES_MMO_ZIGBEE ((psa_algorithm_t)0x02000007)
 
@@ -2244,27 +2245,27 @@ psa_status_t psa_aead_abort(psa_aead_operation_t * operation);
 #define PSA_ALG_SP800_108_COUNTER_CMAC ((psa_algorithm_t)0x08000800)
 
 /**
- * @brief Macro to build a TLS-1.
+ * @brief Macro to build a TLS-1.2 PRF algorithm.
  *
  * @param hash_alg A hash algorithm: a value of type psa_algorithm_t such that
  *                 PSA_ALG_IS_HASH(hash_alg) is true.
  *
- * @return The corresponding TLS-1.
+ * @return The corresponding TLS-1.2 PRF algorithm.
  */
 #define PSA_ALG_TLS12_PRF(hash_alg) /* specification-defined value */
 
 /**
- * @brief Macro to build a TLS-1.
+ * @brief Macro to build a TLS-1.2 PSK-to-MasterSecret algorithm.
  *
  * @param hash_alg A hash algorithm: a value of type psa_algorithm_t such that
  *                 PSA_ALG_IS_HASH(hash_alg) is true.
  *
- * @return The corresponding TLS-1.
+ * @return The corresponding TLS-1.2 PSK to MS algorithm.
  */
 #define PSA_ALG_TLS12_PSK_TO_MS(hash_alg) /* specification-defined value */
 
 /**
- * @brief The TLS 1.
+ * @brief The TLS 1.2 ECJPAKE-to-PMS key-derivation algorithm.
  */
 #define PSA_ALG_TLS12_ECJPAKE_TO_PMS ((psa_algorithm_t)0x08000609)
 
@@ -2521,20 +2522,20 @@ psa_status_t psa_key_derivation_abort(psa_key_derivation_operation_t * operation
     /* specification-defined value */
 
 /**
- * @brief Whether the specified algorithm is a TLS-1.
+ * @brief Whether the specified algorithm is a TLS-1.2 PRF algorithm.
  *
  * @param alg An algorithm identifier: a value of type psa_algorithm_t.
  *
- * @return 1 if alg is a TLS-1.
+ * @return 1 if alg is a TLS-1.2 PRF algorithm, 0 otherwise.
  */
 #define PSA_ALG_IS_TLS12_PRF(alg) /* specification-defined value */
 
 /**
- * @brief Whether the specified algorithm is a TLS-1.
+ * @brief Whether the specified algorithm is a TLS-1.2 PSK to MS algorithm.
  *
  * @param alg An algorithm identifier: a value of type psa_algorithm_t.
  *
- * @return 1 if alg is a TLS-1.
+ * @return 1 if alg is a TLS-1.2 PSK to MS algorithm, 0 otherwise.
  */
 #define PSA_ALG_IS_TLS12_PSK_TO_MS(alg) /* specification-defined value */
 
@@ -2555,27 +2556,28 @@ psa_status_t psa_key_derivation_abort(psa_key_derivation_operation_t * operation
 
 /**
  * @brief This macro returns the maximum supported length of the PSK for the
- *        TLS-1.
+ *        TLS-1.2 PSK-to-MS key derivation.
  */
 #define PSA_TLS12_PSK_TO_MS_PSK_MAX_SIZE /* implementation-defined value */
 
 /**
- * @brief The size of the output from the TLS 1.
+ * @brief The size of the output from the TLS 1.2 ECJPAKE-to-PMS key-derivation
+ *        algorithm, in bytes.
  */
 #define PSA_TLS12_ECJPAKE_TO_PMS_OUTPUT_SIZE 32
 
 /**
- * @brief The RSA PKCS#1 v1.
+ * @brief The RSA PKCS#1 v1.5 message signature scheme, with hashing.
  *
  * @param hash_alg A hash algorithm: a value of type psa_algorithm_t such that
  *                 PSA_ALG_IS_HASH(hash_alg) is true.
  *
- * @return The corresponding RSA PKCS#1 v1.
+ * @return The corresponding RSA PKCS#1 v1.5 signature algorithm.
  */
 #define PSA_ALG_RSA_PKCS1V15_SIGN(hash_alg) /* specification-defined value */
 
 /**
- * @brief The raw RSA PKCS#1 v1.
+ * @brief The raw RSA PKCS#1 v1.5 signature algorithm, without hashing.
  */
 #define PSA_ALG_RSA_PKCS1V15_SIGN_RAW ((psa_algorithm_t) 0x06000200)
 
@@ -2747,11 +2749,12 @@ psa_status_t psa_verify_hash(psa_key_id_t key,
 #define PSA_ALG_IS_SIGN_HASH(alg) /* specification-defined value */
 
 /**
- * @brief Whether the specified algorithm is an RSA PKCS#1 v1.
+ * @brief Whether the specified algorithm is an RSA PKCS#1 v1.5 signature
+ *        algorithm.
  *
  * @param alg An algorithm identifier: a value of type psa_algorithm_t.
  *
- * @return 1 if alg is an RSA PKCS#1 v1.
+ * @return 1 if alg is an RSA PKCS#1 v1.5 signature algorithm, 0 otherwise.
  */
 #define PSA_ALG_IS_RSA_PKCS1V15_SIGN(alg) /* specification-defined value */
 
@@ -2861,7 +2864,7 @@ psa_status_t psa_verify_hash(psa_key_id_t key,
 #define PSA_SIGNATURE_MAX_SIZE /* implementation-defined value */
 
 /**
- * @brief The RSA PKCS#1 v1.
+ * @brief The RSA PKCS#1 v1.5 asymmetric encryption algorithm.
  */
 #define PSA_ALG_RSA_PKCS1V15_CRYPT ((psa_algorithm_t)0x07000200)
 

--- a/headers/storage/1.0/psa/internal_trusted_storage.h
+++ b/headers/storage/1.0/psa/internal_trusted_storage.h
@@ -33,12 +33,12 @@ extern "C" {
 
 /**
  * @brief Set the data associated with the specified uid.
- * 
+ *
  * @param uid          The identifier for the data.
  * @param data_length  The size in bytes of the data in p_data.
  * @param p_data       A buffer of data_length containing the data to store.
  * @param create_flags The flags that the data will be stored with.
- * 
+ *
  * @return A status indicating the success or failure of the operation.
  */
 psa_status_t psa_its_set(psa_storage_uid_t uid,
@@ -48,14 +48,14 @@ psa_status_t psa_its_set(psa_storage_uid_t uid,
 
 /**
  * @brief Retrieve data associated with a provided uid.
- * 
+ *
  * @param uid           The uid value.
  * @param data_offset   The starting offset of the data requested.
  * @param data_size     The amount of data requested.
  * @param p_data        On success, the buffer where the data will be placed.
  * @param p_data_length On success, this will contain size of the data placed in
  *                      p_data.
- * 
+ *
  * @return A status indicating the success or failure of the operation.
  */
 psa_status_t psa_its_get(psa_storage_uid_t uid,
@@ -66,11 +66,11 @@ psa_status_t psa_its_get(psa_storage_uid_t uid,
 
 /**
  * @brief Retrieve the metadata about the provided uid.
- * 
+ *
  * @param uid    The uid value.
  * @param p_info A pointer to the psa_storage_info_t struct that will be
  *               populated with the metadata.
- * 
+ *
  * @return A status indicating the success or failure of the operation.
  */
 psa_status_t psa_its_get_info(psa_storage_uid_t uid,
@@ -78,9 +78,9 @@ psa_status_t psa_its_get_info(psa_storage_uid_t uid,
 
 /**
  * @brief Remove the provided uid and its associated data from the storage.
- * 
+ *
  * @param uid The uid value.
- * 
+ *
  * @return A status indicating the success or failure of the operation.
  */
 psa_status_t psa_its_remove(psa_storage_uid_t uid);

--- a/headers/storage/1.0/psa/protected_storage.h
+++ b/headers/storage/1.0/psa/protected_storage.h
@@ -33,12 +33,12 @@ extern "C" {
 
 /**
  * @brief Set the data associated with the specified uid.
- * 
+ *
  * @param uid          The identifier for the data.
  * @param data_length  The size in bytes of the data in p_data.
  * @param p_data       A buffer containing the data.
  * @param create_flags The flags indicating the properties of the data.
- * 
+ *
  * @return A status indicating the success or failure of the operation.
  */
 psa_status_t psa_ps_set(psa_storage_uid_t uid,
@@ -48,14 +48,14 @@ psa_status_t psa_ps_set(psa_storage_uid_t uid,
 
 /**
  * @brief Retrieve data associated with a provided uid.
- * 
+ *
  * @param uid           The uid value.
  * @param data_offset   The starting offset of the data requested.
  * @param data_size     The amount of data requested.
  * @param p_data        On success, the buffer where the data will be placed.
  * @param p_data_length On success, will contain size of the data placed in
  *                      p_data.
- * 
+ *
  * @return A status indicating the success or failure of the operation.
  */
 psa_status_t psa_ps_get(psa_storage_uid_t uid,
@@ -66,11 +66,11 @@ psa_status_t psa_ps_get(psa_storage_uid_t uid,
 
 /**
  * @brief Retrieve the metadata about the provided uid.
- * 
+ *
  * @param uid    The identifier for the data.
  * @param p_info A pointer to the psa_storage_info_t struct that will be
  *               populated with the metadata.
- * 
+ *
  * @return A status indicating the success or failure of the operation.
  */
 psa_status_t psa_ps_get_info(psa_storage_uid_t uid,
@@ -78,16 +78,16 @@ psa_status_t psa_ps_get_info(psa_storage_uid_t uid,
 
 /**
  * @brief Remove the provided uid and its associated data from the storage.
- * 
+ *
  * @param uid The identifier for the data to be removed.
- * 
+ *
  * @return A status indicating the success or failure of the operation.
  */
 psa_status_t psa_ps_remove(psa_storage_uid_t uid);
 
 /**
  * @brief Reserves storage for the specified uid.
- * 
+ *
  * @param uid          A unique identifier for the asset.
  * @param capacity     The allocated capacity, in bytes, of the uid.
  * @param create_flags Flags indicating properties of the storage.
@@ -98,7 +98,7 @@ psa_status_t psa_ps_create(psa_storage_uid_t uid,
 
 /**
  * @brief Overwrite part of the data of the specified uid.
- * 
+ *
  * @param uid         The unique identifier for the asset.
  * @param data_offset Offset within the asset to start the write.
  * @param data_length The size in bytes of the data in p_data to write.


### PR DESCRIPTION
Some of the descriptions in the reference headers in [/headers](https://github.com/ARM-software/psa-api/blob/main/headers) were being truncated at the first '.', even if this was a decimal point within a version number.

This PR re-generates all of the header files using fixed tooling.