### PR TITLE
Change the bit size used to select a specific ML-DSA key parameter set

### DIFF
--- a/doc/ext-pqc/api.db/psa/crypto-pqc.h
+++ b/doc/ext-pqc/api.db/psa/crypto-pqc.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: Copyright 2018-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+// SPDX-FileCopyrightText: Copyright 2018-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 // SPDX-License-Identifier: Apache-2.0
 
 typedef uint8_t psa_slh_dsa_family_t;

--- a/doc/ext-pqc/api/hash.rst
+++ b/doc/ext-pqc/api/hash.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto-pqc

--- a/doc/ext-pqc/api/mldsa.rst
+++ b/doc/ext-pqc/api/mldsa.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto-pqc
@@ -24,12 +24,11 @@ The |API| supports Module Lattice-based digital signatures (ML-DSA), as defined 
 
         .. versionadded:: 1.3
 
-    The key attribute size of an ML-DSA key is the numeric ML-DSA parameter-set identifier defined in `[FIPS204]`.
-    The values are based on the dimensions of the matrix :math:`A`, and do not directly define the key size in bytes:
+    The key attribute size of an ML-DSA key is a measure of the security strength of the ML-DSA parameter-set in `[FIPS204]`:
 
-    *   ML-DSA-44 : ``key_bits = 44``
-    *   ML-DSA-65 : ``key_bits = 65``
-    *   ML-DSA-87 : ``key_bits = 87``
+    *   ML-DSA-44 : ``key_bits = 128``
+    *   ML-DSA-65 : ``key_bits = 192``
+    *   ML-DSA-87 : ``key_bits = 256``
 
     See also §4 in `[FIPS204]`.
 

--- a/doc/ext-pqc/api/pqc.rst
+++ b/doc/ext-pqc/api/pqc.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 ..  _pqc-api:
@@ -12,7 +12,7 @@ API Reference
     The API defined in this specification will be integrated into a future version of :cite:`PSA-CRYPT`.
 
 .. header:: psa/crypto-pqc
-    :copyright: Copyright 2018-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+    :copyright: Copyright 2018-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
     :license: Apache-2.0
 
     /* This file contains reference definitions for implementation of the

--- a/doc/ext-pqc/references
+++ b/doc/ext-pqc/references
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. reference:: PSA-CRYPT

--- a/doc/ext-pqc/releases
+++ b/doc/ext-pqc/releases
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. release:: Beta 0


### PR DESCRIPTION
Base the key size on the security (collision) strength of the ML-DSA parameter set, rather than on the name of the parameter set.

Fixes #241