### PR TITLE
Fix incorrect typename in custom key creation functions

### DIFF
--- a/doc/crypto/api.db/psa/crypto.h
+++ b/doc/crypto/api.db/psa/crypto.h
@@ -531,7 +531,7 @@ psa_status_t psa_generate_key_custom(const psa_key_attributes_t * attributes,
                                      const psa_custom_key_parameters_t * custom,
                                      const uint8_t * custom_data,
                                      size_t custom_data_length,
-                                     mbedtls_svc_key_id_t * key);
+                                     psa_key_id_t * key);
 psa_status_t psa_generate_random(uint8_t * output,
                                  size_t output_size);
 psa_algorithm_t psa_get_key_algorithm(const psa_key_attributes_t * attributes);
@@ -617,7 +617,7 @@ psa_status_t psa_key_derivation_output_key_custom(const psa_key_attributes_t * a
                                                   const psa_custom_key_parameters_t * custom,
                                                   const uint8_t * custom_data,
                                                   size_t custom_data_length,
-                                                  mbedtls_svc_key_id_t * key);
+                                                  psa_key_id_t * key);
 psa_status_t psa_key_derivation_set_capacity(psa_key_derivation_operation_t * operation,
                                              size_t capacity);
 psa_status_t psa_key_derivation_setup(psa_key_derivation_operation_t * operation,

--- a/doc/crypto/api/keys/management.rst
+++ b/doc/crypto/api/keys/management.rst
@@ -273,7 +273,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
         A buffer containing additional variable-sized production parameters.
     .. param:: size_t custom_data_length
         Length of ``custom_data`` in bytes.
-    .. param:: mbedtls_svc_key_id_t * key
+    .. param:: psa_key_id_t * key
         On success, an identifier for the newly created key.
         For persistent keys, this is the key identifier defined in ``attributes``.
         `PSA_KEY_ID_NULL` on failure.

--- a/doc/crypto/api/ops/key-derivation.rst
+++ b/doc/crypto/api/ops/key-derivation.rst
@@ -1005,7 +1005,7 @@ Key-derivation functions
         A buffer containing additional variable-sized production parameters.
     .. param:: size_t custom_data_length
         Length of ``custom_data`` in bytes.
-    .. param:: mbedtls_svc_key_id_t * key
+    .. param:: psa_key_id_t * key
         On success, an identifier for the newly created key.
         For persistent keys, this is the key identifier defined in ``attributes``.
         `PSA_KEY_ID_NULL` on failure.

--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -18,6 +18,7 @@ Clarifications and fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 *   Clarify the way a 'volatile key' is designated, based on a persistence level of `PSA_KEY_PERSISTENCE_VOLATILE`, to ensure that this is consistent throughout the specification. See :secref:`key-lifetimes`.
+*   Corrected the type of the key id parameter to `psa_generate_key_custom()` and `psa_key_derivation_output_key_custom()`.
 
 Changes between *1.2.1* and *1.3.0*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/headers/crypto/1.3/psa/crypto.h
+++ b/headers/crypto/1.3/psa/crypto.h
@@ -793,7 +793,7 @@ psa_status_t psa_generate_key_custom(const psa_key_attributes_t * attributes,
                                      const psa_custom_key_parameters_t * custom,
                                      const uint8_t * custom_data,
                                      size_t custom_data_length,
-                                     mbedtls_svc_key_id_t * key);
+                                     psa_key_id_t * key);
 
 /**
  * @brief Make a copy of a key.
@@ -2568,7 +2568,7 @@ psa_status_t psa_key_derivation_output_key_custom(const psa_key_attributes_t * a
                                                   const psa_custom_key_parameters_t * custom,
                                                   const uint8_t * custom_data,
                                                   size_t custom_data_length,
-                                                  mbedtls_svc_key_id_t * key);
+                                                  psa_key_id_t * key);
 
 /**
  * @brief Compare output data from a key-derivation operation to an expected


### PR DESCRIPTION
Change `mbedtls_svc_key_id_t` to `psa_key_id_t` in two function parameters introduced in version 1.3.

Fixes #259