### PR TITLE
Clarify how a volatile key is specified

### DIFF
--- a/doc/crypto/api/keys/ids.rst
+++ b/doc/crypto/api/keys/ids.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2018-2022, 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2018-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. _key-identifiers:
@@ -90,7 +90,7 @@ Attribute accessors
 
     The application must choose a value for ``id`` between `PSA_KEY_ID_USER_MIN` and `PSA_KEY_ID_USER_MAX`.
 
-    If the attribute object currently declares the key as volatile, which is the default lifetime of an attribute object, this function sets the lifetime attribute to `PSA_KEY_LIFETIME_PERSISTENT`.
+    If the attribute object currently declares the key as volatile, this function sets the lifetime attribute to `PSA_KEY_LIFETIME_PERSISTENT`. See :secref:`key-lifetimes`.
 
     This function does not access storage, it merely stores the given value in the attribute object. The persistent key will be written to storage when the attribute object is passed to a key creation function such as `psa_import_key()`, `psa_generate_key()`, `psa_generate_key_custom()`, `psa_key_derivation_output_key()`, `psa_key_derivation_output_key_custom()`, `psa_key_agreement()`, `psa_encapsulate()`, `psa_decapsulate()`, `psa_pake_get_shared_key()`, or `psa_copy_key()`.
 

--- a/doc/crypto/api/keys/lifetimes.rst
+++ b/doc/crypto/api/keys/lifetimes.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2018-2022, 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2018-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -24,11 +24,13 @@ Volatile keys
 
 Volatile keys are automatically destroyed when the application instance terminates or on a power reset of the device. Volatile keys can be explicitly destroyed by the application.
 
-Conceptually, a volatile key is stored in RAM. Volatile keys have the lifetime `PSA_KEY_LIFETIME_VOLATILE`.
+Conceptually, a volatile key is stored in RAM. Volatile keys have the persistence level `PSA_KEY_PERSISTENCE_VOLATILE` in the key lifetime value, see :secref:`key-lifetime-encoding`.
+Unless the key lifetime is explicitly set in the key attributes before creating a key, a volatile key will be created with the default `PSA_KEY_LIFETIME_VOLATILE` lifetime value.
 
 To create a volatile key:
 
 1.  Populate a `psa_key_attributes_t` object with the required type, size, policy and other key attributes.
+#.  If a non-default storage location is being used, set the key lifetime in the attributes object.
 #.  Create the key with one of the key creation functions. If successful, these functions output a transient `key identifier <key-identifiers>`.
 
 To destroy a volatile key: call `psa_destroy_key()` with the key identifier. There must be a matching call to `psa_destroy_key()` for each successful call to a create a volatile key.
@@ -60,8 +62,10 @@ To destroy a persistent key: call `psa_destroy_key()` with the key identifier. D
 By default, persistent key material is removed from volatile memory when not in use. Frequently used persistent keys can benefit from caching, depending on the implementation and the application. Caching can be enabled by creating the key with the `PSA_KEY_USAGE_CACHE` policy. Cached keys can be removed from volatile memory by calling `psa_purge_key()`. See also :secref:`memory-cleanup` and :secref:`key-material`.
 
 
-Lifetime encodings
-------------------
+.. _key-lifetime-encoding:
+
+Key lifetime encoding
+---------------------
 
 .. typedef:: uint32_t psa_key_lifetime_t
 
@@ -267,11 +271,13 @@ Attribute accessors
     .. param:: psa_key_attributes_t * attributes
         The attribute object to write to.
     .. param:: psa_key_lifetime_t lifetime
-        The lifetime for the key. If this is `PSA_KEY_LIFETIME_VOLATILE`, the key will be volatile, and the key identifier attribute is reset to `PSA_KEY_ID_NULL`.
+        The lifetime for the key.
+
+        If this is a volatile lifetime (such that :code:`PSA_KEY_LIFETIME_IS_VOLATILE(lifetime)` is true), the key identifier attribute is reset to `PSA_KEY_ID_NULL`.
 
     .. return:: void
 
-    To make a key persistent, give it a persistent key identifier by using `psa_set_key_id()`. By default, a key that has a persistent identifier is stored in the default storage area identifier by `PSA_KEY_LIFETIME_PERSISTENT`. Call this function to choose a storage area, or to explicitly declare the key as volatile.
+    To make a key persistent, give it a persistent key identifier by using `psa_set_key_id()`. By default, a key that has a persistent identifier is stored in the default storage area identifier by `PSA_KEY_LIFETIME_PERSISTENT`. Call this function to choose a specific storage area, or to explicitly declare the key as volatile.
 
     This function does not access storage, it merely stores the given value in the attribute object. The persistent key will be written to storage when the attribute object is passed to a key creation function such as `psa_import_key()`, `psa_generate_key()`, `psa_generate_key_custom()`, `psa_key_derivation_output_key()`, `psa_key_derivation_output_key_custom()`, `psa_key_agreement()`, `psa_encapsulate()`, `psa_decapsulate()`, `psa_pake_get_shared_key()`, or `psa_copy_key()`.
 

--- a/doc/crypto/api/keys/management.rst
+++ b/doc/crypto/api/keys/management.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2018-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2018-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -47,7 +47,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
         *   The key permitted-algorithm policy, see :secref:`permitted-algorithms`.
         *   The key usage flags, see :secref:`key-usage-flags`.
 
-        The following attributes must be set for keys that do not use the default volatile lifetime:
+        The following attributes must be set for keys that do not use the default `PSA_KEY_LIFETIME_VOLATILE` lifetime:
 
         *   The key lifetime, see :secref:`key-lifetimes`.
         *   The key identifier is required for a key with a persistent lifetime, see :secref:`key-identifiers`.
@@ -181,7 +181,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
         *   The key permitted-algorithm policy, see :secref:`permitted-algorithms`.
         *   The key usage flags, see :secref:`key-usage-flags`.
 
-        The following attributes must be set for keys that do not use the default volatile lifetime:
+        The following attributes must be set for keys that do not use the default `PSA_KEY_LIFETIME_VOLATILE` lifetime:
 
         *   The key lifetime, see :secref:`key-lifetimes`.
         *   The key identifier is required for a key with a persistent lifetime, see :secref:`key-identifiers`.
@@ -256,7 +256,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
         *   The key permitted-algorithm policy, see :secref:`permitted-algorithms`.
         *   The key usage flags, see :secref:`key-usage-flags`.
 
-        The following attributes must be set for keys that do not use the default volatile lifetime:
+        The following attributes must be set for keys that do not use the default `PSA_KEY_LIFETIME_VOLATILE` lifetime:
 
         *   The key lifetime, see :secref:`key-lifetimes`.
         *   The key identifier is required for a key with a persistent lifetime, see :secref:`key-identifiers`.
@@ -341,7 +341,7 @@ When creating a key, the attributes for the new key are specified in a `psa_key_
 
         These flags are combined with the source key policy so that both sets of restrictions apply, as described in the documentation of this function.
 
-        The following attributes must be set for keys that do not use the default volatile lifetime:
+        The following attributes must be set for keys that do not use the default `PSA_KEY_LIFETIME_VOLATILE` lifetime:
 
         *   The key lifetime, see :secref:`key-lifetimes`.
         *   The key identifier is required for a key with a persistent lifetime, see :secref:`key-identifiers`.

--- a/doc/crypto/api/ops/key-agreement.rst
+++ b/doc/crypto/api/ops/key-agreement.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2018-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2018-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -152,7 +152,7 @@ Standalone key agreement
         *   The key permitted-algorithm policy, see :secref:`permitted-algorithms`.
         *   The key usage flags, see :secref:`key-usage-flags`.
 
-        The following attributes must be set for keys that do not use the default volatile lifetime:
+        The following attributes must be set for keys that do not use the default `PSA_KEY_LIFETIME_VOLATILE` lifetime:
 
         *   The key lifetime, see :secref:`key-lifetimes`.
         *   The key identifier is required for a key with a persistent lifetime, see :secref:`key-identifiers`.

--- a/doc/crypto/api/ops/key-derivation.rst
+++ b/doc/crypto/api/ops/key-derivation.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2018-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2018-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -885,7 +885,7 @@ Key-derivation functions
             If the key type to be created is `PSA_KEY_TYPE_PASSWORD_HASH`, then the permitted-algorithm policy must be either the same as the current operation's algorithm, or `PSA_ALG_NONE`.
         *   The key usage flags, see :secref:`key-usage-flags`.
 
-        The following attributes must be set for keys that do not use the default volatile lifetime:
+        The following attributes must be set for keys that do not use the default `PSA_KEY_LIFETIME_VOLATILE` lifetime:
 
         *   The key lifetime, see :secref:`key-lifetimes`.
         *   The key identifier is required for a key with a persistent lifetime, see :secref:`key-identifiers`.
@@ -985,7 +985,7 @@ Key-derivation functions
             If the key type to be created is `PSA_KEY_TYPE_PASSWORD_HASH`, then the permitted-algorithm policy must be either the same as the current operation's algorithm, or `PSA_ALG_NONE`.
         *   The key usage flags, see :secref:`key-usage-flags`.
 
-        The following attributes must be set for keys that do not use the default volatile lifetime:
+        The following attributes must be set for keys that do not use the default `PSA_KEY_LIFETIME_VOLATILE` lifetime:
 
         *   The key lifetime, see :secref:`key-lifetimes`.
         *   The key identifier is required for a key with a persistent lifetime, see :secref:`key-identifiers`.

--- a/doc/crypto/api/ops/key-encapsulation.rst
+++ b/doc/crypto/api/ops/key-encapsulation.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2024-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -138,7 +138,7 @@ Key-encapsulation functions
         *   The key permitted-algorithm policy, see :secref:`permitted-algorithms`.
         *   The key usage flags, see :secref:`key-usage-flags`.
 
-        The following attributes must be set for keys that do not use the default volatile lifetime:
+        The following attributes must be set for keys that do not use the default `PSA_KEY_LIFETIME_VOLATILE` lifetime:
 
         *   The key lifetime, see :secref:`key-lifetimes`.
         *   The key identifier is required for a key with a persistent lifetime, see :secref:`key-identifiers`.
@@ -254,7 +254,7 @@ Key-encapsulation functions
         *   The key permitted-algorithm policy, see :secref:`permitted-algorithms`.
         *   The key usage flags, see :secref:`key-usage-flags`.
 
-        The following attributes must be set for keys that do not use the default volatile lifetime:
+        The following attributes must be set for keys that do not use the default `PSA_KEY_LIFETIME_VOLATILE` lifetime:
 
         *   The key lifetime, see :secref:`key-lifetimes`.
         *   The key identifier is required for a key with a persistent lifetime, see :secref:`key-identifiers`.

--- a/doc/crypto/api/ops/pake.rst
+++ b/doc/crypto/api/ops/pake.rst
@@ -1,4 +1,4 @@
-.. SPDX-FileCopyrightText: Copyright 2022-2024 Arm Limited and/or its affiliates <open-source-office@arm.com>
+.. SPDX-FileCopyrightText: Copyright 2022-2025 Arm Limited and/or its affiliates <open-source-office@arm.com>
 .. SPDX-License-Identifier: CC-BY-SA-4.0 AND LicenseRef-Patent-license
 
 .. header:: psa/crypto
@@ -1055,7 +1055,7 @@ Multi-part PAKE operations
         *   The key permitted-algorithm policy, see :secref:`permitted-algorithms`.
         *   The key usage flags, see :secref:`key-usage-flags`.
 
-        The following attributes must be set for keys that do not use the default volatile lifetime:
+        The following attributes must be set for keys that do not use the default `PSA_KEY_LIFETIME_VOLATILE` lifetime:
 
         *   The key lifetime, see :secref:`key-lifetimes`.
         *   The key identifier is required for a key with a persistent lifetime, see :secref:`key-identifiers`.

--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -11,6 +11,14 @@ Document change history
 
 This section provides the detailed changes made between published version of the document.
 
+Changes between *1.3.0* and *1.3.1*
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Clarifications and fixes
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+*
+
 Changes between *1.2.1* and *1.3.0*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/doc/crypto/appendix/history.rst
+++ b/doc/crypto/appendix/history.rst
@@ -17,7 +17,7 @@ Changes between *1.3.0* and *1.3.1*
 Clarifications and fixes
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-*
+*   Clarify the way a 'volatile key' is designated, based on a persistence level of `PSA_KEY_PERSISTENCE_VOLATILE`, to ensure that this is consistent throughout the specification. See :secref:`key-lifetimes`.
 
 Changes between *1.2.1* and *1.3.0*
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/doc/crypto/conf.py
+++ b/doc/crypto/conf.py
@@ -27,12 +27,12 @@ doc_info = {
     'quality': 'REL',
     # Arm document issue number (within that version and quality status)
     # Marked as open issue if not provided
-    'issue_no': 0,
+    'issue_no': 1,
     # Identifies the sequence number of a release candidate of the same issue
     # default to None
     #'release_candidate': 1,
     # Draft status - use this to indicate the document is not ready for publication
-    'draft': False,
+    'draft': True,
 
     # Arm document confidentiality. Must be either Non-confidential or Confidential
     # Marked as open issue if not provided

--- a/doc/crypto/releases
+++ b/doc/crypto/releases
@@ -76,3 +76,10 @@
     New API for key encapsulation.
 
     Support for additional key generation parameters.
+
+.. release:: 1.3.1 Final
+    :date: ? 2025
+    :confidentiality: Non-confidential
+
+    Clarifications and fixes
+


### PR DESCRIPTION
Clarify the way a 'volatile key' is designated, based on a lifetime persistence level of `PSA_KEY_PERSISTENCE_VOLATILE`. Ensure that this is consistent and clear throughout the specification.

Fixes #262