### PR TITLE
Fix url links to CC-BY-SA-4.0

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -2,7 +2,7 @@
 
 ## Text and illustrations
 
-Text and illustrations in this project are licensed under Creative Commons Attribution–Share Alike 4.0 International license (CC BY-SA 4.0). The text of this license can be viewed at https://creativecommons.org/licenses/by/4.0.
+Text and illustrations in this project are licensed under Creative Commons Attribution–Share Alike 4.0 International license (CC BY-SA 4.0). The text of this license can be viewed at https://creativecommons.org/licenses/by-sa/4.0.
 
 **Grant of patent license**. Subject to the terms and conditions of this license (both the CC BY-SA 4.0 Public License and this Patent License), each Licensor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Licensed Material, where such license applies only to those patent claims licensable by such Licensor that are necessarily infringed by their contribution(s) alone or by combination of their contribution(s) with the Licensed Material to which such contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Licensed Material or a contribution incorporated within the Licensed Material constitutes direct or contributory patent infringement, then any licenses granted to You under this license for that Licensed Material shall terminate as of the date such litigation is filed.
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The language in the additional patent license is largely identical to that in se
 
 2. The scope of the defensive termination clause is changed from "any patent licenses granted to You" to "any licenses granted to You". This change is intended to help maintain a healthy ecosystem by providing additional protection to the community against patent litigation claims.
 
-[CC-BY-SA-4.0]:     https://creativecommons.org/licenses/by/4.0
+[CC-BY-SA-4.0]:     https://creativecommons.org/licenses/by-sa/4.0
 [APACHE-2.0]:       https://www.apache.org/licenses/LICENSE-2.0
 [trademarks]:       https://www.arm.com/company/policies/trademarks
 
@@ -135,4 +135,4 @@ Anyone may contribute to the PSA Certified API. Discussion of changes and enhanc
 
 ----
 
-*Copyright 2022-2024 Arm Limited and/or its affiliates*
+*Copyright 2022-2025 Arm Limited and/or its affiliates*


### PR DESCRIPTION
The CC license name is correct in all places, but the urls used in the README.md and LICENSE.md files incorrectly referred to the CC-BY-4.0 license.

(The URLs in the license text within the rendered specification documents are already correct.)