### PR TITLE
Update link to PSA-FFM

### DIFF
--- a/doc/status-code/references
+++ b/doc/status-code/references
@@ -4,7 +4,7 @@
 .. reference:: PSA-FFM
     :title: Arm® Platform Security Architecture Firmware Framework
     :doc_no: DEN 0063
-    :url: developer.arm.com/documentation/den0063.html
+    :url: https://developer.arm.com/documentation/den0063/a
 
 .. reference:: TF-M
     :title: Trusted Firmware-M


### PR DESCRIPTION
Current URL for PSA-FFM returns "We could not find this page".
Update it with the correct for Arm PSA Firmware Framework 1.0.